### PR TITLE
Add api generic funcs

### DIFF
--- a/api/asn.go
+++ b/api/asn.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	"time"
 )
@@ -61,16 +58,7 @@ func getAsn(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/asn/{id} [get]
 func getAsnById(id int) (interface{}, error) {
-	ret := []Asn{}
-	arg := Asn{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from asn where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "asn", (*Asn)(nil))
 }
 
 // @Title getAsns
@@ -80,14 +68,7 @@ func getAsnById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/asn [get]
 func getAsns() (interface{}, error) {
-	ret := []Asn{}
-	queryStr := "select * from asn"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("asn", (*Asn)(nil))
 }
 
 // @Title postAsn
@@ -99,24 +80,7 @@ func getAsns() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/asn [post]
 func postAsn(payload []byte) (interface{}, error) {
-	var v Asn
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO asn("
-	sqlString += "asn"
-	sqlString += ",cachegroup"
-	sqlString += ") VALUES ("
-	sqlString += ":asn"
-	sqlString += ",:cachegroup"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "asn", (*Asn)(nil))
 }
 
 // @Title putAsn
@@ -128,25 +92,7 @@ func postAsn(payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/asn [put]
 func putAsn(id int, payload []byte) (interface{}, error) {
-	var v Asn
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE asn SET "
-	sqlString += "asn = :asn"
-	sqlString += ",cachegroup = :cachegroup"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "asn", (*Asn)(nil))
 }
 
 // @Title delAsnById
@@ -157,11 +103,5 @@ func putAsn(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/asn/{id} [delete]
 func delAsn(id int) (interface{}, error) {
-	arg := Asn{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM asn WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "asn")
 }

--- a/api/cachegroup.go
+++ b/api/cachegroup.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	null "gopkg.in/guregu/null.v3"
 	"time"
@@ -66,16 +63,7 @@ func getCachegroup(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/cachegroup/{id} [get]
 func getCachegroupById(id int) (interface{}, error) {
-	ret := []Cachegroup{}
-	arg := Cachegroup{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from cachegroup where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "cachegroup", (*Cachegroup)(nil))
 }
 
 // @Title getCachegroups
@@ -85,14 +73,7 @@ func getCachegroupById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/cachegroup [get]
 func getCachegroups() (interface{}, error) {
-	ret := []Cachegroup{}
-	queryStr := "select * from cachegroup"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("cachegroup", (*Cachegroup)(nil))
 }
 
 // @Title postCachegroup
@@ -108,32 +89,7 @@ func getCachegroups() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/cachegroup [post]
 func postCachegroup(payload []byte) (interface{}, error) {
-	var v Cachegroup
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO cachegroup("
-	sqlString += "name"
-	sqlString += ",short_name"
-	sqlString += ",latitude"
-	sqlString += ",longitude"
-	sqlString += ",parent_cachegroup_id"
-	sqlString += ",type"
-	sqlString += ") VALUES ("
-	sqlString += ":name"
-	sqlString += ",:short_name"
-	sqlString += ",:latitude"
-	sqlString += ",:longitude"
-	sqlString += ",:parent_cachegroup_id"
-	sqlString += ",:type"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "cachegroup", (*Cachegroup)(nil))
 }
 
 // @Title putCachegroup
@@ -141,37 +97,15 @@ func postCachegroup(payload []byte) (interface{}, error) {
 // @Accept  application/json
 // @Param                 Name json     string   false "name description"
 // @Param            ShortName json     string   false "short_name description"
-// @Param             Latitude json null.Float    true "latitude description"
-// @Param            Longitude json null.Float    true "longitude description"
-// @Param   ParentCachegroupId json   null.Int    true "parent_cachegroup_id description"
+// @Param             Latitude json    float64    true "latitude description"
+// @Param            Longitude json    float64    true "longitude description"
+// @Param   ParentCachegroupId json        int    true "parent_cachegroup_id description"
 // @Param                 Type json      int64   false "type description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/cachegroup [put]
 func putCachegroup(id int, payload []byte) (interface{}, error) {
-	var v Cachegroup
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE cachegroup SET "
-	sqlString += "name = :name"
-	sqlString += ",short_name = :short_name"
-	sqlString += ",latitude = :latitude"
-	sqlString += ",longitude = :longitude"
-	sqlString += ",parent_cachegroup_id = :parent_cachegroup_id"
-	sqlString += ",type = :type"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "cachegroup", (*Cachegroup)(nil))
 }
 
 // @Title delCachegroupById
@@ -182,11 +116,5 @@ func putCachegroup(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/cachegroup/{id} [delete]
 func delCachegroup(id int) (interface{}, error) {
-	arg := Cachegroup{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM cachegroup WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "cachegroup")
 }

--- a/api/cachegroup_parameter.go
+++ b/api/cachegroup_parameter.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	"time"
 )
@@ -60,16 +57,7 @@ func getCachegroupParameter(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/cachegroup_parameter/{id} [get]
 func getCachegroupParameterById(id int) (interface{}, error) {
-	ret := []CachegroupParameter{}
-	arg := CachegroupParameter{Cachegroup: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from cachegroup_parameter where cachegroup=:cachegroup`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "cachegroup_parameter", (*CachegroupParameter)(nil))
 }
 
 // @Title getCachegroupParameters
@@ -79,14 +67,7 @@ func getCachegroupParameterById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/cachegroup_parameter [get]
 func getCachegroupParameters() (interface{}, error) {
-	ret := []CachegroupParameter{}
-	queryStr := "select * from cachegroup_parameter"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("cachegroup_parameter", (*CachegroupParameter)(nil))
 }
 
 // @Title postCachegroupParameter
@@ -98,24 +79,7 @@ func getCachegroupParameters() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/cachegroup_parameter [post]
 func postCachegroupParameter(payload []byte) (interface{}, error) {
-	var v CachegroupParameter
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO cachegroup_parameter("
-	sqlString += "cachegroup"
-	sqlString += ",parameter"
-	sqlString += ") VALUES ("
-	sqlString += ":cachegroup"
-	sqlString += ",:parameter"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "cachegroup_parameter", (*CachegroupParameter)(nil))
 }
 
 // @Title putCachegroupParameter
@@ -127,25 +91,7 @@ func postCachegroupParameter(payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/cachegroup_parameter [put]
 func putCachegroupParameter(id int, payload []byte) (interface{}, error) {
-	var v CachegroupParameter
-	err := json.Unmarshal(payload, &v)
-	v.Cachegroup = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE cachegroup_parameter SET "
-	sqlString += "cachegroup = :cachegroup"
-	sqlString += ",parameter = :parameter"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE cachegroup=:cachegroup"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "cachegroup_parameter", (*CachegroupParameter)(nil))
 }
 
 // @Title delCachegroupParameterById
@@ -156,11 +102,5 @@ func putCachegroupParameter(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/cachegroup_parameter/{id} [delete]
 func delCachegroupParameter(id int) (interface{}, error) {
-	arg := CachegroupParameter{Cachegroup: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM cachegroup_parameter WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "cachegroup_parameter")
 }

--- a/api/cdn.go
+++ b/api/cdn.go
@@ -18,19 +18,15 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	null "gopkg.in/guregu/null.v3"
 	"time"
 )
 
 type Cdn struct {
-	Id            int64       `db:"id" json:"id"`
-	Name          null.String `db:"name" json:"name"`
-	LastUpdated   time.Time   `db:"last_updated" json:"lastUpdated"`
-	DnssecEnabled null.Int    `db:"dnssec_enabled" json:"dnssecEnabled"`
+	Id          int64       `db:"id" json:"id"`
+	Name        null.String `db:"name" json:"name"`
+	LastUpdated time.Time   `db:"last_updated" json:"lastUpdated"`
 }
 
 func handleCdn(method string, id int, payload []byte) (interface{}, error) {
@@ -62,16 +58,7 @@ func getCdn(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/cdn/{id} [get]
 func getCdnById(id int) (interface{}, error) {
-	ret := []Cdn{}
-	arg := Cdn{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from cdn where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "cdn", (*Cdn)(nil))
 }
 
 // @Title getCdns
@@ -81,73 +68,29 @@ func getCdnById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/cdn [get]
 func getCdns() (interface{}, error) {
-	ret := []Cdn{}
-	queryStr := "select * from cdn"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("cdn", (*Cdn)(nil))
 }
 
 // @Title postCdn
 // @Description enter a new cdn
 // @Accept  application/json
 // @Param                 Name json     string    true "name description"
-// @Param        DnssecEnabled json        int    true "dnssec_enabled description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/cdn [post]
 func postCdn(payload []byte) (interface{}, error) {
-	var v Cdn
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO cdn("
-	sqlString += "name"
-	sqlString += ",dnssec_enabled"
-	sqlString += ") VALUES ("
-	sqlString += ":name"
-	sqlString += ",:dnssec_enabled"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "cdn", (*Cdn)(nil))
 }
 
 // @Title putCdn
 // @Description modify an existing cdnentry
 // @Accept  application/json
-// @Param                 Name json null.String    true "name description"
-// @Param        DnssecEnabled json   null.Int    true "dnssec_enabled description"
+// @Param                 Name json     string    true "name description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/cdn [put]
 func putCdn(id int, payload []byte) (interface{}, error) {
-	var v Cdn
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE cdn SET "
-	sqlString += "name = :name"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += ",dnssec_enabled = :dnssec_enabled"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "cdn", (*Cdn)(nil))
 }
 
 // @Title delCdnById
@@ -158,11 +101,5 @@ func putCdn(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/cdn/{id} [delete]
 func delCdn(id int) (interface{}, error) {
-	arg := Cdn{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM cdn WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "cdn")
 }

--- a/api/deliveryservice.go
+++ b/api/deliveryservice.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	null "gopkg.in/guregu/null.v3"
 	"time"
@@ -41,7 +38,7 @@ type Deliveryservice struct {
 	OrgServerFqdn        null.String `db:"org_server_fqdn" json:"orgServerFqdn"`
 	Type                 int64       `db:"type" json:"type"`
 	Profile              int64       `db:"profile" json:"profile"`
-	CdnId                int64       `db:"cdn_id" json:"cdnId"`
+	CdnId                null.Int    `db:"cdn_id" json:"cdnId"`
 	CcrDnsTtl            null.Int    `db:"ccr_dns_ttl" json:"ccrDnsTtl"`
 	GlobalMaxMbps        null.Int    `db:"global_max_mbps" json:"globalMaxMbps"`
 	GlobalMaxTps         null.Int    `db:"global_max_tps" json:"globalMaxTps"`
@@ -69,7 +66,6 @@ type Deliveryservice struct {
 	TrResponseHeaders    null.String `db:"tr_response_headers" json:"trResponseHeaders"`
 	InitialDispersion    null.Int    `db:"initial_dispersion" json:"initialDispersion"`
 	DnsBypassCname       null.String `db:"dns_bypass_cname" json:"dnsBypassCname"`
-	TrRequestHeaders     null.String `db:"tr_request_headers" json:"trRequestHeaders"`
 }
 
 func handleDeliveryservice(method string, id int, payload []byte) (interface{}, error) {
@@ -101,16 +97,7 @@ func getDeliveryservice(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/deliveryservice/{id} [get]
 func getDeliveryserviceById(id int) (interface{}, error) {
-	ret := []Deliveryservice{}
-	arg := Deliveryservice{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from deliveryservice where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "deliveryservice", (*Deliveryservice)(nil))
 }
 
 // @Title getDeliveryservices
@@ -120,14 +107,7 @@ func getDeliveryserviceById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/deliveryservice [get]
 func getDeliveryservices() (interface{}, error) {
-	ret := []Deliveryservice{}
-	queryStr := "select * from deliveryservice"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("deliveryservice", (*Deliveryservice)(nil))
 }
 
 // @Title postDeliveryservice
@@ -146,7 +126,7 @@ func getDeliveryservices() (interface{}, error) {
 // @Param        OrgServerFqdn json     string    true "org_server_fqdn description"
 // @Param                 Type json      int64   false "type description"
 // @Param              Profile json      int64   false "profile description"
-// @Param                CdnId json      int64   false "cdn_id description"
+// @Param                CdnId json        int    true "cdn_id description"
 // @Param            CcrDnsTtl json        int    true "ccr_dns_ttl description"
 // @Param        GlobalMaxMbps json        int    true "global_max_mbps description"
 // @Param         GlobalMaxTps json        int    true "global_max_tps description"
@@ -173,107 +153,11 @@ func getDeliveryservices() (interface{}, error) {
 // @Param    TrResponseHeaders json     string    true "tr_response_headers description"
 // @Param    InitialDispersion json        int    true "initial_dispersion description"
 // @Param       DnsBypassCname json     string    true "dns_bypass_cname description"
-// @Param     TrRequestHeaders json     string    true "tr_request_headers description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/deliveryservice [post]
 func postDeliveryservice(payload []byte) (interface{}, error) {
-	var v Deliveryservice
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO deliveryservice("
-	sqlString += "xml_id"
-	sqlString += ",active"
-	sqlString += ",dscp"
-	sqlString += ",signed"
-	sqlString += ",qstring_ignore"
-	sqlString += ",geo_limit"
-	sqlString += ",http_bypass_fqdn"
-	sqlString += ",dns_bypass_ip"
-	sqlString += ",dns_bypass_ip6"
-	sqlString += ",dns_bypass_ttl"
-	sqlString += ",org_server_fqdn"
-	sqlString += ",type"
-	sqlString += ",profile"
-	sqlString += ",cdn_id"
-	sqlString += ",ccr_dns_ttl"
-	sqlString += ",global_max_mbps"
-	sqlString += ",global_max_tps"
-	sqlString += ",long_desc"
-	sqlString += ",long_desc_1"
-	sqlString += ",long_desc_2"
-	sqlString += ",max_dns_answers"
-	sqlString += ",info_url"
-	sqlString += ",miss_lat"
-	sqlString += ",miss_long"
-	sqlString += ",check_path"
-	sqlString += ",protocol"
-	sqlString += ",ssl_key_version"
-	sqlString += ",ipv6_routing_enabled"
-	sqlString += ",range_request_handling"
-	sqlString += ",edge_header_rewrite"
-	sqlString += ",origin_shield"
-	sqlString += ",mid_header_rewrite"
-	sqlString += ",regex_remap"
-	sqlString += ",cacheurl"
-	sqlString += ",remap_text"
-	sqlString += ",multi_site_origin"
-	sqlString += ",display_name"
-	sqlString += ",tr_response_headers"
-	sqlString += ",initial_dispersion"
-	sqlString += ",dns_bypass_cname"
-	sqlString += ",tr_request_headers"
-	sqlString += ") VALUES ("
-	sqlString += ":xml_id"
-	sqlString += ",:active"
-	sqlString += ",:dscp"
-	sqlString += ",:signed"
-	sqlString += ",:qstring_ignore"
-	sqlString += ",:geo_limit"
-	sqlString += ",:http_bypass_fqdn"
-	sqlString += ",:dns_bypass_ip"
-	sqlString += ",:dns_bypass_ip6"
-	sqlString += ",:dns_bypass_ttl"
-	sqlString += ",:org_server_fqdn"
-	sqlString += ",:type"
-	sqlString += ",:profile"
-	sqlString += ",:cdn_id"
-	sqlString += ",:ccr_dns_ttl"
-	sqlString += ",:global_max_mbps"
-	sqlString += ",:global_max_tps"
-	sqlString += ",:long_desc"
-	sqlString += ",:long_desc_1"
-	sqlString += ",:long_desc_2"
-	sqlString += ",:max_dns_answers"
-	sqlString += ",:info_url"
-	sqlString += ",:miss_lat"
-	sqlString += ",:miss_long"
-	sqlString += ",:check_path"
-	sqlString += ",:protocol"
-	sqlString += ",:ssl_key_version"
-	sqlString += ",:ipv6_routing_enabled"
-	sqlString += ",:range_request_handling"
-	sqlString += ",:edge_header_rewrite"
-	sqlString += ",:origin_shield"
-	sqlString += ",:mid_header_rewrite"
-	sqlString += ",:regex_remap"
-	sqlString += ",:cacheurl"
-	sqlString += ",:remap_text"
-	sqlString += ",:multi_site_origin"
-	sqlString += ",:display_name"
-	sqlString += ",:tr_response_headers"
-	sqlString += ",:initial_dispersion"
-	sqlString += ",:dns_bypass_cname"
-	sqlString += ",:tr_request_headers"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "deliveryservice", (*Deliveryservice)(nil))
 }
 
 // @Title putDeliveryservice
@@ -282,106 +166,48 @@ func postDeliveryservice(payload []byte) (interface{}, error) {
 // @Param                XmlId json     string   false "xml_id description"
 // @Param               Active json      int64   false "active description"
 // @Param                 Dscp json      int64   false "dscp description"
-// @Param               Signed json   null.Int    true "signed description"
-// @Param        QstringIgnore json   null.Int    true "qstring_ignore description"
-// @Param             GeoLimit json   null.Int    true "geo_limit description"
-// @Param       HttpBypassFqdn json null.String    true "http_bypass_fqdn description"
-// @Param          DnsBypassIp json null.String    true "dns_bypass_ip description"
-// @Param         DnsBypassIp6 json null.String    true "dns_bypass_ip6 description"
-// @Param         DnsBypassTtl json   null.Int    true "dns_bypass_ttl description"
-// @Param        OrgServerFqdn json null.String    true "org_server_fqdn description"
+// @Param               Signed json        int    true "signed description"
+// @Param        QstringIgnore json        int    true "qstring_ignore description"
+// @Param             GeoLimit json        int    true "geo_limit description"
+// @Param       HttpBypassFqdn json     string    true "http_bypass_fqdn description"
+// @Param          DnsBypassIp json     string    true "dns_bypass_ip description"
+// @Param         DnsBypassIp6 json     string    true "dns_bypass_ip6 description"
+// @Param         DnsBypassTtl json        int    true "dns_bypass_ttl description"
+// @Param        OrgServerFqdn json     string    true "org_server_fqdn description"
 // @Param                 Type json      int64   false "type description"
 // @Param              Profile json      int64   false "profile description"
-// @Param                CdnId json      int64   false "cdn_id description"
-// @Param            CcrDnsTtl json   null.Int    true "ccr_dns_ttl description"
-// @Param        GlobalMaxMbps json   null.Int    true "global_max_mbps description"
-// @Param         GlobalMaxTps json   null.Int    true "global_max_tps description"
-// @Param             LongDesc json null.String    true "long_desc description"
-// @Param            LongDesc1 json null.String    true "long_desc_1 description"
-// @Param            LongDesc2 json null.String    true "long_desc_2 description"
-// @Param        MaxDnsAnswers json   null.Int    true "max_dns_answers description"
-// @Param              InfoUrl json null.String    true "info_url description"
-// @Param              MissLat json null.Float    true "miss_lat description"
-// @Param             MissLong json null.Float    true "miss_long description"
-// @Param            CheckPath json null.String    true "check_path description"
-// @Param             Protocol json   null.Int    true "protocol description"
-// @Param        SslKeyVersion json   null.Int    true "ssl_key_version description"
-// @Param   Ipv6RoutingEnabled json   null.Int    true "ipv6_routing_enabled description"
-// @Param RangeRequestHandling json   null.Int    true "range_request_handling description"
-// @Param    EdgeHeaderRewrite json null.String    true "edge_header_rewrite description"
-// @Param         OriginShield json null.String    true "origin_shield description"
-// @Param     MidHeaderRewrite json null.String    true "mid_header_rewrite description"
-// @Param           RegexRemap json null.String    true "regex_remap description"
-// @Param             Cacheurl json null.String    true "cacheurl description"
-// @Param            RemapText json null.String    true "remap_text description"
-// @Param      MultiSiteOrigin json   null.Int    true "multi_site_origin description"
+// @Param                CdnId json        int    true "cdn_id description"
+// @Param            CcrDnsTtl json        int    true "ccr_dns_ttl description"
+// @Param        GlobalMaxMbps json        int    true "global_max_mbps description"
+// @Param         GlobalMaxTps json        int    true "global_max_tps description"
+// @Param             LongDesc json     string    true "long_desc description"
+// @Param            LongDesc1 json     string    true "long_desc_1 description"
+// @Param            LongDesc2 json     string    true "long_desc_2 description"
+// @Param        MaxDnsAnswers json        int    true "max_dns_answers description"
+// @Param              InfoUrl json     string    true "info_url description"
+// @Param              MissLat json    float64    true "miss_lat description"
+// @Param             MissLong json    float64    true "miss_long description"
+// @Param            CheckPath json     string    true "check_path description"
+// @Param             Protocol json        int    true "protocol description"
+// @Param        SslKeyVersion json        int    true "ssl_key_version description"
+// @Param   Ipv6RoutingEnabled json        int    true "ipv6_routing_enabled description"
+// @Param RangeRequestHandling json        int    true "range_request_handling description"
+// @Param    EdgeHeaderRewrite json     string    true "edge_header_rewrite description"
+// @Param         OriginShield json     string    true "origin_shield description"
+// @Param     MidHeaderRewrite json     string    true "mid_header_rewrite description"
+// @Param           RegexRemap json     string    true "regex_remap description"
+// @Param             Cacheurl json     string    true "cacheurl description"
+// @Param            RemapText json     string    true "remap_text description"
+// @Param      MultiSiteOrigin json        int    true "multi_site_origin description"
 // @Param          DisplayName json     string   false "display_name description"
-// @Param    TrResponseHeaders json null.String    true "tr_response_headers description"
-// @Param    InitialDispersion json   null.Int    true "initial_dispersion description"
-// @Param       DnsBypassCname json null.String    true "dns_bypass_cname description"
-// @Param     TrRequestHeaders json null.String    true "tr_request_headers description"
+// @Param    TrResponseHeaders json     string    true "tr_response_headers description"
+// @Param    InitialDispersion json        int    true "initial_dispersion description"
+// @Param       DnsBypassCname json     string    true "dns_bypass_cname description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/deliveryservice [put]
 func putDeliveryservice(id int, payload []byte) (interface{}, error) {
-	var v Deliveryservice
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE deliveryservice SET "
-	sqlString += "xml_id = :xml_id"
-	sqlString += ",active = :active"
-	sqlString += ",dscp = :dscp"
-	sqlString += ",signed = :signed"
-	sqlString += ",qstring_ignore = :qstring_ignore"
-	sqlString += ",geo_limit = :geo_limit"
-	sqlString += ",http_bypass_fqdn = :http_bypass_fqdn"
-	sqlString += ",dns_bypass_ip = :dns_bypass_ip"
-	sqlString += ",dns_bypass_ip6 = :dns_bypass_ip6"
-	sqlString += ",dns_bypass_ttl = :dns_bypass_ttl"
-	sqlString += ",org_server_fqdn = :org_server_fqdn"
-	sqlString += ",type = :type"
-	sqlString += ",profile = :profile"
-	sqlString += ",cdn_id = :cdn_id"
-	sqlString += ",ccr_dns_ttl = :ccr_dns_ttl"
-	sqlString += ",global_max_mbps = :global_max_mbps"
-	sqlString += ",global_max_tps = :global_max_tps"
-	sqlString += ",long_desc = :long_desc"
-	sqlString += ",long_desc_1 = :long_desc_1"
-	sqlString += ",long_desc_2 = :long_desc_2"
-	sqlString += ",max_dns_answers = :max_dns_answers"
-	sqlString += ",info_url = :info_url"
-	sqlString += ",miss_lat = :miss_lat"
-	sqlString += ",miss_long = :miss_long"
-	sqlString += ",check_path = :check_path"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += ",protocol = :protocol"
-	sqlString += ",ssl_key_version = :ssl_key_version"
-	sqlString += ",ipv6_routing_enabled = :ipv6_routing_enabled"
-	sqlString += ",range_request_handling = :range_request_handling"
-	sqlString += ",edge_header_rewrite = :edge_header_rewrite"
-	sqlString += ",origin_shield = :origin_shield"
-	sqlString += ",mid_header_rewrite = :mid_header_rewrite"
-	sqlString += ",regex_remap = :regex_remap"
-	sqlString += ",cacheurl = :cacheurl"
-	sqlString += ",remap_text = :remap_text"
-	sqlString += ",multi_site_origin = :multi_site_origin"
-	sqlString += ",display_name = :display_name"
-	sqlString += ",tr_response_headers = :tr_response_headers"
-	sqlString += ",initial_dispersion = :initial_dispersion"
-	sqlString += ",dns_bypass_cname = :dns_bypass_cname"
-	sqlString += ",tr_request_headers = :tr_request_headers"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "deliveryservice", (*Deliveryservice)(nil))
 }
 
 // @Title delDeliveryserviceById
@@ -392,11 +218,5 @@ func putDeliveryservice(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/deliveryservice/{id} [delete]
 func delDeliveryservice(id int) (interface{}, error) {
-	arg := Deliveryservice{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM deliveryservice WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "deliveryservice")
 }

--- a/api/deliveryservice_regex.go
+++ b/api/deliveryservice_regex.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	null "gopkg.in/guregu/null.v3"
 )
@@ -60,16 +57,7 @@ func getDeliveryserviceRegex(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/deliveryservice_regex/{id} [get]
 func getDeliveryserviceRegexById(id int) (interface{}, error) {
-	ret := []DeliveryserviceRegex{}
-	arg := DeliveryserviceRegex{Deliveryservice: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from deliveryservice_regex where deliveryservice=:deliveryservice`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "deliveryservice_regex", (*DeliveryserviceRegex)(nil))
 }
 
 // @Title getDeliveryserviceRegexs
@@ -79,14 +67,7 @@ func getDeliveryserviceRegexById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/deliveryservice_regex [get]
 func getDeliveryserviceRegexs() (interface{}, error) {
-	ret := []DeliveryserviceRegex{}
-	queryStr := "select * from deliveryservice_regex"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("deliveryservice_regex", (*DeliveryserviceRegex)(nil))
 }
 
 // @Title postDeliveryserviceRegex
@@ -99,26 +80,7 @@ func getDeliveryserviceRegexs() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/deliveryservice_regex [post]
 func postDeliveryserviceRegex(payload []byte) (interface{}, error) {
-	var v DeliveryserviceRegex
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO deliveryservice_regex("
-	sqlString += "deliveryservice"
-	sqlString += ",regex"
-	sqlString += ",set_number"
-	sqlString += ") VALUES ("
-	sqlString += ":deliveryservice"
-	sqlString += ",:regex"
-	sqlString += ",:set_number"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "deliveryservice_regex", (*DeliveryserviceRegex)(nil))
 }
 
 // @Title putDeliveryserviceRegex
@@ -126,29 +88,12 @@ func postDeliveryserviceRegex(payload []byte) (interface{}, error) {
 // @Accept  application/json
 // @Param      Deliveryservice json      int64   false "deliveryservice description"
 // @Param                Regex json      int64   false "regex description"
-// @Param            SetNumber json   null.Int    true "set_number description"
+// @Param            SetNumber json        int    true "set_number description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/deliveryservice_regex [put]
 func putDeliveryserviceRegex(id int, payload []byte) (interface{}, error) {
-	var v DeliveryserviceRegex
-	err := json.Unmarshal(payload, &v)
-	v.Deliveryservice = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	sqlString := "UPDATE deliveryservice_regex SET "
-	sqlString += "deliveryservice = :deliveryservice"
-	sqlString += ",regex = :regex"
-	sqlString += ",set_number = :set_number"
-	sqlString += " WHERE deliveryservice=:deliveryservice"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "deliveryservice_regex", (*DeliveryserviceRegex)(nil))
 }
 
 // @Title delDeliveryserviceRegexById
@@ -159,11 +104,5 @@ func putDeliveryserviceRegex(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/deliveryservice_regex/{id} [delete]
 func delDeliveryserviceRegex(id int) (interface{}, error) {
-	arg := DeliveryserviceRegex{Deliveryservice: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM deliveryservice_regex WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "deliveryservice_regex")
 }

--- a/api/deliveryservice_server.go
+++ b/api/deliveryservice_server.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	"time"
 )
@@ -60,16 +57,7 @@ func getDeliveryserviceServer(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/deliveryservice_server/{id} [get]
 func getDeliveryserviceServerById(id int) (interface{}, error) {
-	ret := []DeliveryserviceServer{}
-	arg := DeliveryserviceServer{Deliveryservice: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from deliveryservice_server where deliveryservice=:deliveryservice`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "deliveryservice_server", (*DeliveryserviceServer)(nil))
 }
 
 // @Title getDeliveryserviceServers
@@ -79,14 +67,7 @@ func getDeliveryserviceServerById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/deliveryservice_server [get]
 func getDeliveryserviceServers() (interface{}, error) {
-	ret := []DeliveryserviceServer{}
-	queryStr := "select * from deliveryservice_server"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("deliveryservice_server", (*DeliveryserviceServer)(nil))
 }
 
 // @Title postDeliveryserviceServer
@@ -98,24 +79,7 @@ func getDeliveryserviceServers() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/deliveryservice_server [post]
 func postDeliveryserviceServer(payload []byte) (interface{}, error) {
-	var v DeliveryserviceServer
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO deliveryservice_server("
-	sqlString += "deliveryservice"
-	sqlString += ",server"
-	sqlString += ") VALUES ("
-	sqlString += ":deliveryservice"
-	sqlString += ",:server"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "deliveryservice_server", (*DeliveryserviceServer)(nil))
 }
 
 // @Title putDeliveryserviceServer
@@ -127,25 +91,7 @@ func postDeliveryserviceServer(payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/deliveryservice_server [put]
 func putDeliveryserviceServer(id int, payload []byte) (interface{}, error) {
-	var v DeliveryserviceServer
-	err := json.Unmarshal(payload, &v)
-	v.Deliveryservice = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE deliveryservice_server SET "
-	sqlString += "deliveryservice = :deliveryservice"
-	sqlString += ",server = :server"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE deliveryservice=:deliveryservice"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "deliveryservice_server", (*DeliveryserviceServer)(nil))
 }
 
 // @Title delDeliveryserviceServerById
@@ -156,11 +102,5 @@ func putDeliveryserviceServer(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/deliveryservice_server/{id} [delete]
 func delDeliveryserviceServer(id int) (interface{}, error) {
-	arg := DeliveryserviceServer{Deliveryservice: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM deliveryservice_server WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "deliveryservice_server")
 }

--- a/api/deliveryservice_tmuser.go
+++ b/api/deliveryservice_tmuser.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	"time"
 )
@@ -60,16 +57,7 @@ func getDeliveryserviceTmuser(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/deliveryservice_tmuser/{id} [get]
 func getDeliveryserviceTmuserById(id int) (interface{}, error) {
-	ret := []DeliveryserviceTmuser{}
-	arg := DeliveryserviceTmuser{Deliveryservice: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from deliveryservice_tmuser where deliveryservice=:deliveryservice`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "deliveryservice_tmuser", (*DeliveryserviceTmuser)(nil))
 }
 
 // @Title getDeliveryserviceTmusers
@@ -79,14 +67,7 @@ func getDeliveryserviceTmuserById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/deliveryservice_tmuser [get]
 func getDeliveryserviceTmusers() (interface{}, error) {
-	ret := []DeliveryserviceTmuser{}
-	queryStr := "select * from deliveryservice_tmuser"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("deliveryservice_tmuser", (*DeliveryserviceTmuser)(nil))
 }
 
 // @Title postDeliveryserviceTmuser
@@ -98,24 +79,7 @@ func getDeliveryserviceTmusers() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/deliveryservice_tmuser [post]
 func postDeliveryserviceTmuser(payload []byte) (interface{}, error) {
-	var v DeliveryserviceTmuser
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO deliveryservice_tmuser("
-	sqlString += "deliveryservice"
-	sqlString += ",tm_user_id"
-	sqlString += ") VALUES ("
-	sqlString += ":deliveryservice"
-	sqlString += ",:tm_user_id"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "deliveryservice_tmuser", (*DeliveryserviceTmuser)(nil))
 }
 
 // @Title putDeliveryserviceTmuser
@@ -127,25 +91,7 @@ func postDeliveryserviceTmuser(payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/deliveryservice_tmuser [put]
 func putDeliveryserviceTmuser(id int, payload []byte) (interface{}, error) {
-	var v DeliveryserviceTmuser
-	err := json.Unmarshal(payload, &v)
-	v.Deliveryservice = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE deliveryservice_tmuser SET "
-	sqlString += "deliveryservice = :deliveryservice"
-	sqlString += ",tm_user_id = :tm_user_id"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE deliveryservice=:deliveryservice"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "deliveryservice_tmuser", (*DeliveryserviceTmuser)(nil))
 }
 
 // @Title delDeliveryserviceTmuserById
@@ -156,11 +102,5 @@ func putDeliveryserviceTmuser(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/deliveryservice_tmuser/{id} [delete]
 func delDeliveryserviceTmuser(id int) (interface{}, error) {
-	arg := DeliveryserviceTmuser{Deliveryservice: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM deliveryservice_tmuser WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "deliveryservice_tmuser")
 }

--- a/api/division.go
+++ b/api/division.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	"time"
 )
@@ -60,16 +57,7 @@ func getDivision(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/division/{id} [get]
 func getDivisionById(id int) (interface{}, error) {
-	ret := []Division{}
-	arg := Division{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from division where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "division", (*Division)(nil))
 }
 
 // @Title getDivisions
@@ -79,14 +67,7 @@ func getDivisionById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/division [get]
 func getDivisions() (interface{}, error) {
-	ret := []Division{}
-	queryStr := "select * from division"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("division", (*Division)(nil))
 }
 
 // @Title postDivision
@@ -97,22 +78,7 @@ func getDivisions() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/division [post]
 func postDivision(payload []byte) (interface{}, error) {
-	var v Division
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO division("
-	sqlString += "name"
-	sqlString += ") VALUES ("
-	sqlString += ":name"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "division", (*Division)(nil))
 }
 
 // @Title putDivision
@@ -123,24 +89,7 @@ func postDivision(payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/division [put]
 func putDivision(id int, payload []byte) (interface{}, error) {
-	var v Division
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE division SET "
-	sqlString += "name = :name"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "division", (*Division)(nil))
 }
 
 // @Title delDivisionById
@@ -151,11 +100,5 @@ func putDivision(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/division/{id} [delete]
 func delDivision(id int) (interface{}, error) {
-	arg := Division{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM division WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "division")
 }

--- a/api/federation.go
+++ b/api/federation.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	null "gopkg.in/guregu/null.v3"
 	"time"
@@ -63,16 +60,7 @@ func getFederation(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation/{id} [get]
 func getFederationById(id int) (interface{}, error) {
-	ret := []Federation{}
-	arg := Federation{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from federation where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "federation", (*Federation)(nil))
 }
 
 // @Title getFederations
@@ -82,14 +70,7 @@ func getFederationById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation [get]
 func getFederations() (interface{}, error) {
-	ret := []Federation{}
-	queryStr := "select * from federation"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("federation", (*Federation)(nil))
 }
 
 // @Title postFederation
@@ -102,26 +83,7 @@ func getFederations() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation [post]
 func postFederation(payload []byte) (interface{}, error) {
-	var v Federation
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO federation("
-	sqlString += "cname"
-	sqlString += ",description"
-	sqlString += ",ttl"
-	sqlString += ") VALUES ("
-	sqlString += ":cname"
-	sqlString += ",:description"
-	sqlString += ",:ttl"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "federation", (*Federation)(nil))
 }
 
 // @Title putFederation
@@ -134,26 +96,7 @@ func postFederation(payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation [put]
 func putFederation(id int, payload []byte) (interface{}, error) {
-	var v Federation
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE federation SET "
-	sqlString += "cname = :cname"
-	sqlString += ",description = :description"
-	sqlString += ",ttl = :ttl"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "federation", (*Federation)(nil))
 }
 
 // @Title delFederationById
@@ -164,11 +107,5 @@ func putFederation(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation/{id} [delete]
 func delFederation(id int) (interface{}, error) {
-	arg := Federation{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM federation WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "federation")
 }

--- a/api/federation_deliveryservice.go
+++ b/api/federation_deliveryservice.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	"time"
 )
@@ -60,16 +57,7 @@ func getFederationDeliveryservice(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation_deliveryservice/{id} [get]
 func getFederationDeliveryserviceById(id int) (interface{}, error) {
-	ret := []FederationDeliveryservice{}
-	arg := FederationDeliveryservice{Federation: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from federation_deliveryservice where federation=:federation`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "federation_deliveryservice", (*FederationDeliveryservice)(nil))
 }
 
 // @Title getFederationDeliveryservices
@@ -79,14 +67,7 @@ func getFederationDeliveryserviceById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation_deliveryservice [get]
 func getFederationDeliveryservices() (interface{}, error) {
-	ret := []FederationDeliveryservice{}
-	queryStr := "select * from federation_deliveryservice"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("federation_deliveryservice", (*FederationDeliveryservice)(nil))
 }
 
 // @Title postFederationDeliveryservice
@@ -98,24 +79,7 @@ func getFederationDeliveryservices() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation_deliveryservice [post]
 func postFederationDeliveryservice(payload []byte) (interface{}, error) {
-	var v FederationDeliveryservice
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO federation_deliveryservice("
-	sqlString += "federation"
-	sqlString += ",deliveryservice"
-	sqlString += ") VALUES ("
-	sqlString += ":federation"
-	sqlString += ",:deliveryservice"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "federation_deliveryservice", (*FederationDeliveryservice)(nil))
 }
 
 // @Title putFederationDeliveryservice
@@ -127,25 +91,7 @@ func postFederationDeliveryservice(payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation_deliveryservice [put]
 func putFederationDeliveryservice(id int, payload []byte) (interface{}, error) {
-	var v FederationDeliveryservice
-	err := json.Unmarshal(payload, &v)
-	v.Federation = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE federation_deliveryservice SET "
-	sqlString += "federation = :federation"
-	sqlString += ",deliveryservice = :deliveryservice"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE federation=:federation"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "federation_deliveryservice", (*FederationDeliveryservice)(nil))
 }
 
 // @Title delFederationDeliveryserviceById
@@ -156,11 +102,5 @@ func putFederationDeliveryservice(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation_deliveryservice/{id} [delete]
 func delFederationDeliveryservice(id int) (interface{}, error) {
-	arg := FederationDeliveryservice{Federation: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM federation_deliveryservice WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "federation_deliveryservice")
 }

--- a/api/federation_federation_resolver.go
+++ b/api/federation_federation_resolver.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	"time"
 )
@@ -60,16 +57,7 @@ func getFederationFederationResolver(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation_federation_resolver/{id} [get]
 func getFederationFederationResolverById(id int) (interface{}, error) {
-	ret := []FederationFederationResolver{}
-	arg := FederationFederationResolver{Federation: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from federation_federation_resolver where federation=:federation`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "federation_federation_resolver", (*FederationFederationResolver)(nil))
 }
 
 // @Title getFederationFederationResolvers
@@ -79,14 +67,7 @@ func getFederationFederationResolverById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation_federation_resolver [get]
 func getFederationFederationResolvers() (interface{}, error) {
-	ret := []FederationFederationResolver{}
-	queryStr := "select * from federation_federation_resolver"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("federation_federation_resolver", (*FederationFederationResolver)(nil))
 }
 
 // @Title postFederationFederationResolver
@@ -98,24 +79,7 @@ func getFederationFederationResolvers() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation_federation_resolver [post]
 func postFederationFederationResolver(payload []byte) (interface{}, error) {
-	var v FederationFederationResolver
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO federation_federation_resolver("
-	sqlString += "federation"
-	sqlString += ",federation_resolver"
-	sqlString += ") VALUES ("
-	sqlString += ":federation"
-	sqlString += ",:federation_resolver"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "federation_federation_resolver", (*FederationFederationResolver)(nil))
 }
 
 // @Title putFederationFederationResolver
@@ -127,25 +91,7 @@ func postFederationFederationResolver(payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation_federation_resolver [put]
 func putFederationFederationResolver(id int, payload []byte) (interface{}, error) {
-	var v FederationFederationResolver
-	err := json.Unmarshal(payload, &v)
-	v.Federation = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE federation_federation_resolver SET "
-	sqlString += "federation = :federation"
-	sqlString += ",federation_resolver = :federation_resolver"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE federation=:federation"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "federation_federation_resolver", (*FederationFederationResolver)(nil))
 }
 
 // @Title delFederationFederationResolverById
@@ -156,11 +102,5 @@ func putFederationFederationResolver(id int, payload []byte) (interface{}, error
 // @Resource /api/2.0
 // @Router /api/2.0/federation_federation_resolver/{id} [delete]
 func delFederationFederationResolver(id int) (interface{}, error) {
-	arg := FederationFederationResolver{Federation: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM federation_federation_resolver WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "federation_federation_resolver")
 }

--- a/api/federation_resolver.go
+++ b/api/federation_resolver.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	"time"
 )
@@ -61,16 +58,7 @@ func getFederationResolver(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation_resolver/{id} [get]
 func getFederationResolverById(id int) (interface{}, error) {
-	ret := []FederationResolver{}
-	arg := FederationResolver{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from federation_resolver where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "federation_resolver", (*FederationResolver)(nil))
 }
 
 // @Title getFederationResolvers
@@ -80,14 +68,7 @@ func getFederationResolverById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation_resolver [get]
 func getFederationResolvers() (interface{}, error) {
-	ret := []FederationResolver{}
-	queryStr := "select * from federation_resolver"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("federation_resolver", (*FederationResolver)(nil))
 }
 
 // @Title postFederationResolver
@@ -99,24 +80,7 @@ func getFederationResolvers() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation_resolver [post]
 func postFederationResolver(payload []byte) (interface{}, error) {
-	var v FederationResolver
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO federation_resolver("
-	sqlString += "ip_address"
-	sqlString += ",type"
-	sqlString += ") VALUES ("
-	sqlString += ":ip_address"
-	sqlString += ",:type"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "federation_resolver", (*FederationResolver)(nil))
 }
 
 // @Title putFederationResolver
@@ -128,25 +92,7 @@ func postFederationResolver(payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation_resolver [put]
 func putFederationResolver(id int, payload []byte) (interface{}, error) {
-	var v FederationResolver
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE federation_resolver SET "
-	sqlString += "ip_address = :ip_address"
-	sqlString += ",type = :type"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "federation_resolver", (*FederationResolver)(nil))
 }
 
 // @Title delFederationResolverById
@@ -157,11 +103,5 @@ func putFederationResolver(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation_resolver/{id} [delete]
 func delFederationResolver(id int) (interface{}, error) {
-	arg := FederationResolver{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM federation_resolver WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "federation_resolver")
 }

--- a/api/federation_tmuser.go
+++ b/api/federation_tmuser.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	"time"
 )
@@ -61,16 +58,7 @@ func getFederationTmuser(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation_tmuser/{id} [get]
 func getFederationTmuserById(id int) (interface{}, error) {
-	ret := []FederationTmuser{}
-	arg := FederationTmuser{Federation: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from federation_tmuser where federation=:federation`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "federation_tmuser", (*FederationTmuser)(nil))
 }
 
 // @Title getFederationTmusers
@@ -80,14 +68,7 @@ func getFederationTmuserById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation_tmuser [get]
 func getFederationTmusers() (interface{}, error) {
-	ret := []FederationTmuser{}
-	queryStr := "select * from federation_tmuser"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("federation_tmuser", (*FederationTmuser)(nil))
 }
 
 // @Title postFederationTmuser
@@ -100,26 +81,7 @@ func getFederationTmusers() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation_tmuser [post]
 func postFederationTmuser(payload []byte) (interface{}, error) {
-	var v FederationTmuser
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO federation_tmuser("
-	sqlString += "federation"
-	sqlString += ",tm_user"
-	sqlString += ",role"
-	sqlString += ") VALUES ("
-	sqlString += ":federation"
-	sqlString += ",:tm_user"
-	sqlString += ",:role"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "federation_tmuser", (*FederationTmuser)(nil))
 }
 
 // @Title putFederationTmuser
@@ -132,26 +94,7 @@ func postFederationTmuser(payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation_tmuser [put]
 func putFederationTmuser(id int, payload []byte) (interface{}, error) {
-	var v FederationTmuser
-	err := json.Unmarshal(payload, &v)
-	v.Federation = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE federation_tmuser SET "
-	sqlString += "federation = :federation"
-	sqlString += ",tm_user = :tm_user"
-	sqlString += ",role = :role"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE federation=:federation"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "federation_tmuser", (*FederationTmuser)(nil))
 }
 
 // @Title delFederationTmuserById
@@ -162,11 +105,5 @@ func putFederationTmuser(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/federation_tmuser/{id} [delete]
 func delFederationTmuser(id int) (interface{}, error) {
-	arg := FederationTmuser{Federation: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM federation_tmuser WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "federation_tmuser")
 }

--- a/api/generic.go
+++ b/api/generic.go
@@ -1,0 +1,195 @@
+// Copyright 2015 Comcast Cable Communications Management, LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
+	"reflect"
+	"time"
+)
+
+// genericGetById gets a generic value from SQL from a table via 'select where id ='
+// The returnType MUST be a nil pointer to the type to be populated from SQL.
+func genericGetById(id int, table string, returnTypeNilPtr interface{}) (interface{}, error) {
+	nstmt, err := db.GlobalDB.PrepareNamed("select * from " + table + " where id=:id")
+	if err != nil {
+		return nil, err
+	}
+	defer nstmt.Close()
+
+	returnType := reflect.TypeOf(returnTypeNilPtr).Elem()
+	slicePtr := reflect.New(reflect.SliceOf(returnType))
+	//	slicePtr.Elem().Set(reflect.MakeSlice(reflect.SliceOf(myType), 0, 0))
+	err = nstmt.Select(slicePtr.Interface(), struct{ Id int64 }{int64(id)})
+	if err != nil {
+		return nil, err
+	}
+
+	return reflect.Indirect(slicePtr).Interface(), nil
+}
+
+func genericGet(table string, returnTypeNilPtr interface{}) (interface{}, error) {
+	queryStr := "select * from " + table
+
+	returnType := reflect.TypeOf(returnTypeNilPtr).Elem()
+	slicePtr := reflect.New(reflect.SliceOf(returnType))
+	err := db.GlobalDB.Select(slicePtr.Interface(), queryStr)
+	if err != nil {
+		return nil, err
+	}
+	return reflect.Indirect(slicePtr).Interface(), nil
+}
+
+// buildInsertQuery builds an insert query from obj's "db" tags (as used by sqlx)
+// returns an error if obj is not a struct
+// TODO(require mysql to enable ANSI_QUOTES and use SQL92 quotes for tables and fields?)
+// TODO(put skipped fields [id, last_updated] as constant map somewhere? Take as parameter?)
+// TODO(Take ID field name as parameter?)
+// TODO(put in DB package?)
+func buildInsertQuery(table string, obj interface{}) (string, error) {
+	tp := reflect.TypeOf(obj)
+	if tp.Kind() != reflect.Struct {
+		return "", errors.New("object is not a struct: " + tp.Kind().String())
+	}
+
+	s := `INSERT INTO ` + table + `(`
+	valueStr := ""
+	for i := 0; i < tp.NumField(); i++ {
+		f := tp.Field(i)
+		dbFieldName := f.Tag.Get("db")
+
+		// skip id, last_updated, as done by the generate tool
+		if dbFieldName == "" || dbFieldName == "id" || dbFieldName == "last_updated" {
+			continue
+		}
+
+		s += dbFieldName + ", "
+		valueStr += ":" + dbFieldName + ", "
+	}
+
+	if valueStr == "" {
+		return "", errors.New("object has no 'db' tagged fields")
+	}
+
+	s = s[:len(s)-2]                      // remove trailing ,
+	valueStr = valueStr[:len(valueStr)-2] // remove trailing ,
+	s += ") VALUES (" + valueStr + ")"
+	return s, nil
+}
+
+// buildUpdateQuery builds an update query from obj's "db" tags (as used by sqlx)
+// returns an error if obj is not a struct
+// TODO(require mysql to enable ANSI_QUOTES and use SQL92 quotes for tables and fields?)
+// TODO(put skipped fields [id, last_updated] as constant map somewhere? Take as parameter?)
+// TODO(put in DB package?)
+func buildUpdateQuery(table string, obj interface{}) (string, error) {
+	tp := reflect.TypeOf(obj)
+	if tp.Kind() != reflect.Struct {
+		return "", errors.New("object is not a struct: " + tp.Kind().String())
+	}
+
+	s := `UPDATE ` + table + ` SET `
+	for i := 0; i < tp.NumField(); i++ {
+		f := tp.Field(i)
+		dbFieldName := f.Tag.Get("db")
+
+		// skip id, last_updated, as done by the generate tool
+		if dbFieldName == "" || dbFieldName == "id" || dbFieldName == "last_updated" {
+			continue
+		}
+
+		s += dbFieldName + " = :" + dbFieldName + ", "
+	}
+
+	s = s[:len(s)-2] // remove trailing ,
+	s += " WHERE id = :id"
+	return s, nil
+}
+
+func genericPost(payload []byte, table string, payloadTypeNilPtr interface{}) (interface{}, error) {
+	tp := reflect.TypeOf(payloadTypeNilPtr).Elem()
+	reflectPtr := reflect.New(tp)
+	v := reflectPtr.Interface()
+
+	err := json.Unmarshal(payload, &v)
+	if err != nil {
+		return nil, err
+	}
+
+	sqlStr, err := buildInsertQuery(table, reflect.Zero(tp).Interface())
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := db.GlobalDB.NamedExec(sqlStr, v)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func genericPut(id int, payload []byte, table string, payloadTypeNilPtr interface{}) (interface{}, error) {
+	tp := reflect.TypeOf(payloadTypeNilPtr).Elem()
+	reflectPtr := reflect.New(tp)
+	reflectVal := reflect.Indirect(reflectPtr)
+	v := reflectPtr.Interface()
+
+	err := json.Unmarshal(payload, &v)
+	if err != nil {
+		return nil, err
+	}
+
+	idFieldName := "Id" // TODO(Constant somewhere? Function parameter?)
+	idFieldValue := reflectVal.FieldByName(idFieldName)
+	emptyval := reflect.Value{}
+	if idFieldValue == emptyval {
+		return nil, errors.New("payload type has no Id field")
+	}
+	if !idFieldValue.CanSet() {
+		return nil, errors.New("payload type Id field cannot be set.")
+	}
+	if idFieldValue.Kind() != reflect.Int64 {
+		return nil, errors.New("payload type Id field is not an int64")
+	}
+	idFieldValue.SetInt(int64(id))
+
+	lastUpdatedFieldName := "LastUpdated" // TODO(Constant somewhere? Function parameter?)
+	lastUpdatedFieldValue := reflectVal.FieldByName(lastUpdatedFieldName)
+	if lastUpdatedFieldValue != (reflect.Value{}) && lastUpdatedFieldValue.CanSet() && lastUpdatedFieldValue.Type() == reflect.TypeOf((*time.Time)(nil)) {
+		lastUpdatedFieldValue.Set(reflect.ValueOf(time.Now()))
+	}
+
+	sqlString, err := buildUpdateQuery(table, reflect.Zero(tp).Interface())
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := db.GlobalDB.NamedExec(sqlString, v)
+	if err != nil {
+		return nil, err
+	}
+	return result, err
+}
+
+func genericDelete(id int, table string) (interface{}, error) {
+	result, err := db.GlobalDB.NamedExec("DELETE FROM "+table+" WHERE id=:id", struct{ Id int64 }{int64(id)})
+	if err != nil {
+		return nil, err
+	}
+	return result, err
+}

--- a/api/goose_db_version.go
+++ b/api/goose_db_version.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	"time"
 )
@@ -61,16 +58,7 @@ func getGooseDbVersion(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/goose_db_version/{id} [get]
 func getGooseDbVersionById(id int) (interface{}, error) {
-	ret := []GooseDbVersion{}
-	arg := GooseDbVersion{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from goose_db_version where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "goose_db_version", (*GooseDbVersion)(nil))
 }
 
 // @Title getGooseDbVersions
@@ -80,14 +68,7 @@ func getGooseDbVersionById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/goose_db_version [get]
 func getGooseDbVersions() (interface{}, error) {
-	ret := []GooseDbVersion{}
-	queryStr := "select * from goose_db_version"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("goose_db_version", (*GooseDbVersion)(nil))
 }
 
 // @Title postGooseDbVersion
@@ -100,26 +81,7 @@ func getGooseDbVersions() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/goose_db_version [post]
 func postGooseDbVersion(payload []byte) (interface{}, error) {
-	var v GooseDbVersion
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO goose_db_version("
-	sqlString += "version_id"
-	sqlString += ",is_applied"
-	sqlString += ",tstamp"
-	sqlString += ") VALUES ("
-	sqlString += ":version_id"
-	sqlString += ",:is_applied"
-	sqlString += ",:tstamp"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "goose_db_version", (*GooseDbVersion)(nil))
 }
 
 // @Title putGooseDbVersion
@@ -132,24 +94,7 @@ func postGooseDbVersion(payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/goose_db_version [put]
 func putGooseDbVersion(id int, payload []byte) (interface{}, error) {
-	var v GooseDbVersion
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	sqlString := "UPDATE goose_db_version SET "
-	sqlString += "version_id = :version_id"
-	sqlString += ",is_applied = :is_applied"
-	sqlString += ",tstamp = :tstamp"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "goose_db_version", (*GooseDbVersion)(nil))
 }
 
 // @Title delGooseDbVersionById
@@ -160,11 +105,5 @@ func putGooseDbVersion(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/goose_db_version/{id} [delete]
 func delGooseDbVersion(id int) (interface{}, error) {
-	arg := GooseDbVersion{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM goose_db_version WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "goose_db_version")
 }

--- a/api/hwinfo.go
+++ b/api/hwinfo.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	"time"
 )
@@ -62,16 +59,7 @@ func getHwinfo(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/hwinfo/{id} [get]
 func getHwinfoById(id int) (interface{}, error) {
-	ret := []Hwinfo{}
-	arg := Hwinfo{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from hwinfo where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "hwinfo", (*Hwinfo)(nil))
 }
 
 // @Title getHwinfos
@@ -81,14 +69,7 @@ func getHwinfoById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/hwinfo [get]
 func getHwinfos() (interface{}, error) {
-	ret := []Hwinfo{}
-	queryStr := "select * from hwinfo"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("hwinfo", (*Hwinfo)(nil))
 }
 
 // @Title postHwinfo
@@ -101,26 +82,7 @@ func getHwinfos() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/hwinfo [post]
 func postHwinfo(payload []byte) (interface{}, error) {
-	var v Hwinfo
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO hwinfo("
-	sqlString += "serverid"
-	sqlString += ",description"
-	sqlString += ",val"
-	sqlString += ") VALUES ("
-	sqlString += ":serverid"
-	sqlString += ",:description"
-	sqlString += ",:val"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "hwinfo", (*Hwinfo)(nil))
 }
 
 // @Title putHwinfo
@@ -133,26 +95,7 @@ func postHwinfo(payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/hwinfo [put]
 func putHwinfo(id int, payload []byte) (interface{}, error) {
-	var v Hwinfo
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE hwinfo SET "
-	sqlString += "serverid = :serverid"
-	sqlString += ",description = :description"
-	sqlString += ",val = :val"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "hwinfo", (*Hwinfo)(nil))
 }
 
 // @Title delHwinfoById
@@ -163,11 +106,5 @@ func putHwinfo(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/hwinfo/{id} [delete]
 func delHwinfo(id int) (interface{}, error) {
-	arg := Hwinfo{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM hwinfo WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "hwinfo")
 }

--- a/api/job.go
+++ b/api/job.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	null "gopkg.in/guregu/null.v3"
 	"time"
@@ -72,16 +69,7 @@ func getJob(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/job/{id} [get]
 func getJobById(id int) (interface{}, error) {
-	ret := []Job{}
-	arg := Job{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from job where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "job", (*Job)(nil))
 }
 
 // @Title getJobs
@@ -91,14 +79,7 @@ func getJobById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/job [get]
 func getJobs() (interface{}, error) {
-	ret := []Job{}
-	queryStr := "select * from job"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("job", (*Job)(nil))
 }
 
 // @Title postJob
@@ -120,94 +101,29 @@ func getJobs() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/job [post]
 func postJob(payload []byte) (interface{}, error) {
-	var v Job
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO job("
-	sqlString += "agent"
-	sqlString += ",object_type"
-	sqlString += ",object_name"
-	sqlString += ",keyword"
-	sqlString += ",parameters"
-	sqlString += ",asset_url"
-	sqlString += ",asset_type"
-	sqlString += ",status"
-	sqlString += ",start_time"
-	sqlString += ",entered_time"
-	sqlString += ",job_user"
-	sqlString += ",job_deliveryservice"
-	sqlString += ") VALUES ("
-	sqlString += ":agent"
-	sqlString += ",:object_type"
-	sqlString += ",:object_name"
-	sqlString += ",:keyword"
-	sqlString += ",:parameters"
-	sqlString += ",:asset_url"
-	sqlString += ",:asset_type"
-	sqlString += ",:status"
-	sqlString += ",:start_time"
-	sqlString += ",:entered_time"
-	sqlString += ",:job_user"
-	sqlString += ",:job_deliveryservice"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "job", (*Job)(nil))
 }
 
 // @Title putJob
 // @Description modify an existing jobentry
 // @Accept  application/json
-// @Param                Agent json   null.Int    true "agent description"
-// @Param           ObjectType json null.String    true "object_type description"
-// @Param           ObjectName json null.String    true "object_name description"
+// @Param                Agent json        int    true "agent description"
+// @Param           ObjectType json     string    true "object_type description"
+// @Param           ObjectName json     string    true "object_name description"
 // @Param              Keyword json     string   false "keyword description"
-// @Param           Parameters json null.String    true "parameters description"
+// @Param           Parameters json     string    true "parameters description"
 // @Param             AssetUrl json     string   false "asset_url description"
 // @Param            AssetType json     string   false "asset_type description"
 // @Param               Status json      int64   false "status description"
 // @Param            StartTime json  time.Time   false "start_time description"
 // @Param          EnteredTime json  time.Time   false "entered_time description"
 // @Param              JobUser json      int64   false "job_user description"
-// @Param   JobDeliveryservice json   null.Int    true "job_deliveryservice description"
+// @Param   JobDeliveryservice json        int    true "job_deliveryservice description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/job [put]
 func putJob(id int, payload []byte) (interface{}, error) {
-	var v Job
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE job SET "
-	sqlString += "agent = :agent"
-	sqlString += ",object_type = :object_type"
-	sqlString += ",object_name = :object_name"
-	sqlString += ",keyword = :keyword"
-	sqlString += ",parameters = :parameters"
-	sqlString += ",asset_url = :asset_url"
-	sqlString += ",asset_type = :asset_type"
-	sqlString += ",status = :status"
-	sqlString += ",start_time = :start_time"
-	sqlString += ",entered_time = :entered_time"
-	sqlString += ",job_user = :job_user"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += ",job_deliveryservice = :job_deliveryservice"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "job", (*Job)(nil))
 }
 
 // @Title delJobById
@@ -218,11 +134,5 @@ func putJob(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/job/{id} [delete]
 func delJob(id int) (interface{}, error) {
-	arg := Job{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM job WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "job")
 }

--- a/api/job_agent.go
+++ b/api/job_agent.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	null "gopkg.in/guregu/null.v3"
 	"time"
@@ -63,16 +60,7 @@ func getJobAgent(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/job_agent/{id} [get]
 func getJobAgentById(id int) (interface{}, error) {
-	ret := []JobAgent{}
-	arg := JobAgent{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from job_agent where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "job_agent", (*JobAgent)(nil))
 }
 
 // @Title getJobAgents
@@ -82,14 +70,7 @@ func getJobAgentById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/job_agent [get]
 func getJobAgents() (interface{}, error) {
-	ret := []JobAgent{}
-	queryStr := "select * from job_agent"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("job_agent", (*JobAgent)(nil))
 }
 
 // @Title postJobAgent
@@ -102,58 +83,20 @@ func getJobAgents() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/job_agent [post]
 func postJobAgent(payload []byte) (interface{}, error) {
-	var v JobAgent
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO job_agent("
-	sqlString += "name"
-	sqlString += ",description"
-	sqlString += ",active"
-	sqlString += ") VALUES ("
-	sqlString += ":name"
-	sqlString += ",:description"
-	sqlString += ",:active"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "job_agent", (*JobAgent)(nil))
 }
 
 // @Title putJobAgent
 // @Description modify an existing job_agententry
 // @Accept  application/json
-// @Param                 Name json null.String    true "name description"
-// @Param          Description json null.String    true "description description"
+// @Param                 Name json     string    true "name description"
+// @Param          Description json     string    true "description description"
 // @Param               Active json      int64   false "active description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/job_agent [put]
 func putJobAgent(id int, payload []byte) (interface{}, error) {
-	var v JobAgent
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE job_agent SET "
-	sqlString += "name = :name"
-	sqlString += ",description = :description"
-	sqlString += ",active = :active"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "job_agent", (*JobAgent)(nil))
 }
 
 // @Title delJobAgentById
@@ -164,11 +107,5 @@ func putJobAgent(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/job_agent/{id} [delete]
 func delJobAgent(id int) (interface{}, error) {
-	arg := JobAgent{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM job_agent WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "job_agent")
 }

--- a/api/job_result.go
+++ b/api/job_result.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	null "gopkg.in/guregu/null.v3"
 	"time"
@@ -64,16 +61,7 @@ func getJobResult(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/job_result/{id} [get]
 func getJobResultById(id int) (interface{}, error) {
-	ret := []JobResult{}
-	arg := JobResult{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from job_result where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "job_result", (*JobResult)(nil))
 }
 
 // @Title getJobResults
@@ -83,14 +71,7 @@ func getJobResultById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/job_result [get]
 func getJobResults() (interface{}, error) {
-	ret := []JobResult{}
-	queryStr := "select * from job_result"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("job_result", (*JobResult)(nil))
 }
 
 // @Title postJobResult
@@ -104,28 +85,7 @@ func getJobResults() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/job_result [post]
 func postJobResult(payload []byte) (interface{}, error) {
-	var v JobResult
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO job_result("
-	sqlString += "job"
-	sqlString += ",agent"
-	sqlString += ",result"
-	sqlString += ",description"
-	sqlString += ") VALUES ("
-	sqlString += ":job"
-	sqlString += ",:agent"
-	sqlString += ",:result"
-	sqlString += ",:description"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "job_result", (*JobResult)(nil))
 }
 
 // @Title putJobResult
@@ -134,32 +94,12 @@ func postJobResult(payload []byte) (interface{}, error) {
 // @Param                  Job json      int64   false "job description"
 // @Param                Agent json      int64   false "agent description"
 // @Param               Result json     string   false "result description"
-// @Param          Description json null.String    true "description description"
+// @Param          Description json     string    true "description description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/job_result [put]
 func putJobResult(id int, payload []byte) (interface{}, error) {
-	var v JobResult
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE job_result SET "
-	sqlString += "job = :job"
-	sqlString += ",agent = :agent"
-	sqlString += ",result = :result"
-	sqlString += ",description = :description"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "job_result", (*JobResult)(nil))
 }
 
 // @Title delJobResultById
@@ -170,11 +110,5 @@ func putJobResult(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/job_result/{id} [delete]
 func delJobResult(id int) (interface{}, error) {
-	arg := JobResult{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM job_result WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "job_result")
 }

--- a/api/job_status.go
+++ b/api/job_status.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	null "gopkg.in/guregu/null.v3"
 	"time"
@@ -62,16 +59,7 @@ func getJobStatus(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/job_status/{id} [get]
 func getJobStatusById(id int) (interface{}, error) {
-	ret := []JobStatus{}
-	arg := JobStatus{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from job_status where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "job_status", (*JobStatus)(nil))
 }
 
 // @Title getJobStatuss
@@ -81,14 +69,7 @@ func getJobStatusById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/job_status [get]
 func getJobStatuss() (interface{}, error) {
-	ret := []JobStatus{}
-	queryStr := "select * from job_status"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("job_status", (*JobStatus)(nil))
 }
 
 // @Title postJobStatus
@@ -100,54 +81,19 @@ func getJobStatuss() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/job_status [post]
 func postJobStatus(payload []byte) (interface{}, error) {
-	var v JobStatus
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO job_status("
-	sqlString += "name"
-	sqlString += ",description"
-	sqlString += ") VALUES ("
-	sqlString += ":name"
-	sqlString += ",:description"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "job_status", (*JobStatus)(nil))
 }
 
 // @Title putJobStatus
 // @Description modify an existing job_statusentry
 // @Accept  application/json
-// @Param                 Name json null.String    true "name description"
-// @Param          Description json null.String    true "description description"
+// @Param                 Name json     string    true "name description"
+// @Param          Description json     string    true "description description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/job_status [put]
 func putJobStatus(id int, payload []byte) (interface{}, error) {
-	var v JobStatus
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE job_status SET "
-	sqlString += "name = :name"
-	sqlString += ",description = :description"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "job_status", (*JobStatus)(nil))
 }
 
 // @Title delJobStatusById
@@ -158,11 +104,5 @@ func putJobStatus(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/job_status/{id} [delete]
 func delJobStatus(id int) (interface{}, error) {
-	arg := JobStatus{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM job_status WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "job_status")
 }

--- a/api/log.go
+++ b/api/log.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	null "gopkg.in/guregu/null.v3"
 	"time"
@@ -64,16 +61,7 @@ func getLog(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/log/{id} [get]
 func getLogById(id int) (interface{}, error) {
-	ret := []Log{}
-	arg := Log{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from log where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "log", (*Log)(nil))
 }
 
 // @Title getLogs
@@ -83,14 +71,7 @@ func getLogById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/log [get]
 func getLogs() (interface{}, error) {
-	ret := []Log{}
-	queryStr := "select * from log"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("log", (*Log)(nil))
 }
 
 // @Title postLog
@@ -104,62 +85,21 @@ func getLogs() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/log [post]
 func postLog(payload []byte) (interface{}, error) {
-	var v Log
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO log("
-	sqlString += "level"
-	sqlString += ",message"
-	sqlString += ",tm_user"
-	sqlString += ",ticketnum"
-	sqlString += ") VALUES ("
-	sqlString += ":level"
-	sqlString += ",:message"
-	sqlString += ",:tm_user"
-	sqlString += ",:ticketnum"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "log", (*Log)(nil))
 }
 
 // @Title putLog
 // @Description modify an existing logentry
 // @Accept  application/json
-// @Param                Level json null.String    true "level description"
+// @Param                Level json     string    true "level description"
 // @Param              Message json     string   false "message description"
 // @Param               TmUser json      int64   false "tm_user description"
-// @Param            Ticketnum json null.String    true "ticketnum description"
+// @Param            Ticketnum json     string    true "ticketnum description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/log [put]
 func putLog(id int, payload []byte) (interface{}, error) {
-	var v Log
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE log SET "
-	sqlString += "level = :level"
-	sqlString += ",message = :message"
-	sqlString += ",tm_user = :tm_user"
-	sqlString += ",ticketnum = :ticketnum"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "log", (*Log)(nil))
 }
 
 // @Title delLogById
@@ -170,11 +110,5 @@ func putLog(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/log/{id} [delete]
 func delLog(id int) (interface{}, error) {
-	arg := Log{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM log WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "log")
 }

--- a/api/parameter.go
+++ b/api/parameter.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	"time"
 )
@@ -62,16 +59,7 @@ func getParameter(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/parameter/{id} [get]
 func getParameterById(id int) (interface{}, error) {
-	ret := []Parameter{}
-	arg := Parameter{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from parameter where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "parameter", (*Parameter)(nil))
 }
 
 // @Title getParameters
@@ -81,14 +69,7 @@ func getParameterById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/parameter [get]
 func getParameters() (interface{}, error) {
-	ret := []Parameter{}
-	queryStr := "select * from parameter"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("parameter", (*Parameter)(nil))
 }
 
 // @Title postParameter
@@ -101,26 +82,7 @@ func getParameters() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/parameter [post]
 func postParameter(payload []byte) (interface{}, error) {
-	var v Parameter
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO parameter("
-	sqlString += "name"
-	sqlString += ",config_file"
-	sqlString += ",value"
-	sqlString += ") VALUES ("
-	sqlString += ":name"
-	sqlString += ",:config_file"
-	sqlString += ",:value"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "parameter", (*Parameter)(nil))
 }
 
 // @Title putParameter
@@ -133,26 +95,7 @@ func postParameter(payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/parameter [put]
 func putParameter(id int, payload []byte) (interface{}, error) {
-	var v Parameter
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE parameter SET "
-	sqlString += "name = :name"
-	sqlString += ",config_file = :config_file"
-	sqlString += ",value = :value"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "parameter", (*Parameter)(nil))
 }
 
 // @Title delParameterById
@@ -163,11 +106,5 @@ func putParameter(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/parameter/{id} [delete]
 func delParameter(id int) (interface{}, error) {
-	arg := Parameter{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM parameter WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "parameter")
 }

--- a/api/phys_location.go
+++ b/api/phys_location.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	null "gopkg.in/guregu/null.v3"
 	"time"
@@ -71,16 +68,7 @@ func getPhysLocation(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/phys_location/{id} [get]
 func getPhysLocationById(id int) (interface{}, error) {
-	ret := []PhysLocation{}
-	arg := PhysLocation{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from phys_location where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "phys_location", (*PhysLocation)(nil))
 }
 
 // @Title getPhysLocations
@@ -90,14 +78,7 @@ func getPhysLocationById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/phys_location [get]
 func getPhysLocations() (interface{}, error) {
-	ret := []PhysLocation{}
-	queryStr := "select * from phys_location"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("phys_location", (*PhysLocation)(nil))
 }
 
 // @Title postPhysLocation
@@ -118,42 +99,7 @@ func getPhysLocations() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/phys_location [post]
 func postPhysLocation(payload []byte) (interface{}, error) {
-	var v PhysLocation
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO phys_location("
-	sqlString += "name"
-	sqlString += ",short_name"
-	sqlString += ",address"
-	sqlString += ",city"
-	sqlString += ",state"
-	sqlString += ",zip"
-	sqlString += ",poc"
-	sqlString += ",phone"
-	sqlString += ",email"
-	sqlString += ",comments"
-	sqlString += ",region"
-	sqlString += ") VALUES ("
-	sqlString += ":name"
-	sqlString += ",:short_name"
-	sqlString += ",:address"
-	sqlString += ",:city"
-	sqlString += ",:state"
-	sqlString += ",:zip"
-	sqlString += ",:poc"
-	sqlString += ",:phone"
-	sqlString += ",:email"
-	sqlString += ",:comments"
-	sqlString += ",:region"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "phys_location", (*PhysLocation)(nil))
 }
 
 // @Title putPhysLocation
@@ -165,43 +111,16 @@ func postPhysLocation(payload []byte) (interface{}, error) {
 // @Param                 City json     string   false "city description"
 // @Param                State json     string   false "state description"
 // @Param                  Zip json     string   false "zip description"
-// @Param                  Poc json null.String    true "poc description"
-// @Param                Phone json null.String    true "phone description"
-// @Param                Email json null.String    true "email description"
-// @Param             Comments json null.String    true "comments description"
+// @Param                  Poc json     string    true "poc description"
+// @Param                Phone json     string    true "phone description"
+// @Param                Email json     string    true "email description"
+// @Param             Comments json     string    true "comments description"
 // @Param               Region json      int64   false "region description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/phys_location [put]
 func putPhysLocation(id int, payload []byte) (interface{}, error) {
-	var v PhysLocation
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE phys_location SET "
-	sqlString += "name = :name"
-	sqlString += ",short_name = :short_name"
-	sqlString += ",address = :address"
-	sqlString += ",city = :city"
-	sqlString += ",state = :state"
-	sqlString += ",zip = :zip"
-	sqlString += ",poc = :poc"
-	sqlString += ",phone = :phone"
-	sqlString += ",email = :email"
-	sqlString += ",comments = :comments"
-	sqlString += ",region = :region"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "phys_location", (*PhysLocation)(nil))
 }
 
 // @Title delPhysLocationById
@@ -212,11 +131,5 @@ func putPhysLocation(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/phys_location/{id} [delete]
 func delPhysLocation(id int) (interface{}, error) {
-	arg := PhysLocation{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM phys_location WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "phys_location")
 }

--- a/api/profile.go
+++ b/api/profile.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	null "gopkg.in/guregu/null.v3"
 	"time"
@@ -62,16 +59,7 @@ func getProfile(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/profile/{id} [get]
 func getProfileById(id int) (interface{}, error) {
-	ret := []Profile{}
-	arg := Profile{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from profile where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "profile", (*Profile)(nil))
 }
 
 // @Title getProfiles
@@ -81,14 +69,7 @@ func getProfileById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/profile [get]
 func getProfiles() (interface{}, error) {
-	ret := []Profile{}
-	queryStr := "select * from profile"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("profile", (*Profile)(nil))
 }
 
 // @Title postProfile
@@ -100,54 +81,19 @@ func getProfiles() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/profile [post]
 func postProfile(payload []byte) (interface{}, error) {
-	var v Profile
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO profile("
-	sqlString += "name"
-	sqlString += ",description"
-	sqlString += ") VALUES ("
-	sqlString += ":name"
-	sqlString += ",:description"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "profile", (*Profile)(nil))
 }
 
 // @Title putProfile
 // @Description modify an existing profileentry
 // @Accept  application/json
 // @Param                 Name json     string   false "name description"
-// @Param          Description json null.String    true "description description"
+// @Param          Description json     string    true "description description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/profile [put]
 func putProfile(id int, payload []byte) (interface{}, error) {
-	var v Profile
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE profile SET "
-	sqlString += "name = :name"
-	sqlString += ",description = :description"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "profile", (*Profile)(nil))
 }
 
 // @Title delProfileById
@@ -158,11 +104,5 @@ func putProfile(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/profile/{id} [delete]
 func delProfile(id int) (interface{}, error) {
-	arg := Profile{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM profile WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "profile")
 }

--- a/api/profile_parameter.go
+++ b/api/profile_parameter.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	"time"
 )
@@ -60,16 +57,7 @@ func getProfileParameter(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/profile_parameter/{id} [get]
 func getProfileParameterById(id int) (interface{}, error) {
-	ret := []ProfileParameter{}
-	arg := ProfileParameter{Profile: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from profile_parameter where profile=:profile`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "profile_parameter", (*ProfileParameter)(nil))
 }
 
 // @Title getProfileParameters
@@ -79,14 +67,7 @@ func getProfileParameterById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/profile_parameter [get]
 func getProfileParameters() (interface{}, error) {
-	ret := []ProfileParameter{}
-	queryStr := "select * from profile_parameter"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("profile_parameter", (*ProfileParameter)(nil))
 }
 
 // @Title postProfileParameter
@@ -98,24 +79,7 @@ func getProfileParameters() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/profile_parameter [post]
 func postProfileParameter(payload []byte) (interface{}, error) {
-	var v ProfileParameter
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO profile_parameter("
-	sqlString += "profile"
-	sqlString += ",parameter"
-	sqlString += ") VALUES ("
-	sqlString += ":profile"
-	sqlString += ",:parameter"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "profile_parameter", (*ProfileParameter)(nil))
 }
 
 // @Title putProfileParameter
@@ -127,25 +91,7 @@ func postProfileParameter(payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/profile_parameter [put]
 func putProfileParameter(id int, payload []byte) (interface{}, error) {
-	var v ProfileParameter
-	err := json.Unmarshal(payload, &v)
-	v.Profile = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE profile_parameter SET "
-	sqlString += "profile = :profile"
-	sqlString += ",parameter = :parameter"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE profile=:profile"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "profile_parameter", (*ProfileParameter)(nil))
 }
 
 // @Title delProfileParameterById
@@ -156,11 +102,5 @@ func putProfileParameter(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/profile_parameter/{id} [delete]
 func delProfileParameter(id int) (interface{}, error) {
-	arg := ProfileParameter{Profile: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM profile_parameter WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "profile_parameter")
 }

--- a/api/regex.go
+++ b/api/regex.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	"time"
 )
@@ -61,16 +58,7 @@ func getRegex(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/regex/{id} [get]
 func getRegexById(id int) (interface{}, error) {
-	ret := []Regex{}
-	arg := Regex{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from regex where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "regex", (*Regex)(nil))
 }
 
 // @Title getRegexs
@@ -80,14 +68,7 @@ func getRegexById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/regex [get]
 func getRegexs() (interface{}, error) {
-	ret := []Regex{}
-	queryStr := "select * from regex"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("regex", (*Regex)(nil))
 }
 
 // @Title postRegex
@@ -99,24 +80,7 @@ func getRegexs() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/regex [post]
 func postRegex(payload []byte) (interface{}, error) {
-	var v Regex
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO regex("
-	sqlString += "pattern"
-	sqlString += ",type"
-	sqlString += ") VALUES ("
-	sqlString += ":pattern"
-	sqlString += ",:type"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "regex", (*Regex)(nil))
 }
 
 // @Title putRegex
@@ -128,25 +92,7 @@ func postRegex(payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/regex [put]
 func putRegex(id int, payload []byte) (interface{}, error) {
-	var v Regex
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE regex SET "
-	sqlString += "pattern = :pattern"
-	sqlString += ",type = :type"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "regex", (*Regex)(nil))
 }
 
 // @Title delRegexById
@@ -157,11 +103,5 @@ func putRegex(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/regex/{id} [delete]
 func delRegex(id int) (interface{}, error) {
-	arg := Regex{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM regex WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "regex")
 }

--- a/api/region.go
+++ b/api/region.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	"time"
 )
@@ -61,16 +58,7 @@ func getRegion(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/region/{id} [get]
 func getRegionById(id int) (interface{}, error) {
-	ret := []Region{}
-	arg := Region{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from region where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "region", (*Region)(nil))
 }
 
 // @Title getRegions
@@ -80,14 +68,7 @@ func getRegionById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/region [get]
 func getRegions() (interface{}, error) {
-	ret := []Region{}
-	queryStr := "select * from region"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("region", (*Region)(nil))
 }
 
 // @Title postRegion
@@ -99,24 +80,7 @@ func getRegions() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/region [post]
 func postRegion(payload []byte) (interface{}, error) {
-	var v Region
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO region("
-	sqlString += "name"
-	sqlString += ",division"
-	sqlString += ") VALUES ("
-	sqlString += ":name"
-	sqlString += ",:division"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "region", (*Region)(nil))
 }
 
 // @Title putRegion
@@ -128,25 +92,7 @@ func postRegion(payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/region [put]
 func putRegion(id int, payload []byte) (interface{}, error) {
-	var v Region
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE region SET "
-	sqlString += "name = :name"
-	sqlString += ",division = :division"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "region", (*Region)(nil))
 }
 
 // @Title delRegionById
@@ -157,11 +103,5 @@ func putRegion(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/region/{id} [delete]
 func delRegion(id int) (interface{}, error) {
-	arg := Region{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM region WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "region")
 }

--- a/api/role.go
+++ b/api/role.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	null "gopkg.in/guregu/null.v3"
 )
@@ -61,16 +58,7 @@ func getRole(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/role/{id} [get]
 func getRoleById(id int) (interface{}, error) {
-	ret := []Role{}
-	arg := Role{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from role where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "role", (*Role)(nil))
 }
 
 // @Title getRoles
@@ -80,14 +68,7 @@ func getRoleById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/role [get]
 func getRoles() (interface{}, error) {
-	ret := []Role{}
-	queryStr := "select * from role"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("role", (*Role)(nil))
 }
 
 // @Title postRole
@@ -100,56 +81,20 @@ func getRoles() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/role [post]
 func postRole(payload []byte) (interface{}, error) {
-	var v Role
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO role("
-	sqlString += "name"
-	sqlString += ",description"
-	sqlString += ",priv_level"
-	sqlString += ") VALUES ("
-	sqlString += ":name"
-	sqlString += ",:description"
-	sqlString += ",:priv_level"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "role", (*Role)(nil))
 }
 
 // @Title putRole
 // @Description modify an existing roleentry
 // @Accept  application/json
 // @Param                 Name json     string   false "name description"
-// @Param          Description json null.String    true "description description"
+// @Param          Description json     string    true "description description"
 // @Param            PrivLevel json      int64   false "priv_level description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/role [put]
 func putRole(id int, payload []byte) (interface{}, error) {
-	var v Role
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	sqlString := "UPDATE role SET "
-	sqlString += "name = :name"
-	sqlString += ",description = :description"
-	sqlString += ",priv_level = :priv_level"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "role", (*Role)(nil))
 }
 
 // @Title delRoleById
@@ -160,11 +105,5 @@ func putRole(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/role/{id} [delete]
 func delRole(id int) (interface{}, error) {
-	arg := Role{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM role WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "role")
 }

--- a/api/server.go
+++ b/api/server.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	null "gopkg.in/guregu/null.v3"
 	"time"
@@ -47,7 +44,7 @@ type Server struct {
 	Status         int64       `db:"status" json:"status"`
 	UpdPending     int64       `db:"upd_pending" json:"updPending"`
 	Profile        int64       `db:"profile" json:"profile"`
-	CdnId          int64       `db:"cdn_id" json:"cdnId"`
+	CdnId          null.Int    `db:"cdn_id" json:"cdnId"`
 	MgmtIpAddress  null.String `db:"mgmt_ip_address" json:"mgmtIpAddress"`
 	MgmtIpNetmask  null.String `db:"mgmt_ip_netmask" json:"mgmtIpNetmask"`
 	MgmtIpGateway  null.String `db:"mgmt_ip_gateway" json:"mgmtIpGateway"`
@@ -90,16 +87,7 @@ func getServer(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/server/{id} [get]
 func getServerById(id int) (interface{}, error) {
-	ret := []Server{}
-	arg := Server{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from server where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "server", (*Server)(nil))
 }
 
 // @Title getServers
@@ -109,14 +97,7 @@ func getServerById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/server [get]
 func getServers() (interface{}, error) {
-	ret := []Server{}
-	queryStr := "select * from server"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("server", (*Server)(nil))
 }
 
 // @Title postServer
@@ -141,7 +122,7 @@ func getServers() (interface{}, error) {
 // @Param               Status json      int64   false "status description"
 // @Param           UpdPending json      int64   false "upd_pending description"
 // @Param              Profile json      int64   false "profile description"
-// @Param                CdnId json      int64   false "cdn_id description"
+// @Param                CdnId json        int    true "cdn_id description"
 // @Param        MgmtIpAddress json     string    true "mgmt_ip_address description"
 // @Param        MgmtIpNetmask json     string    true "mgmt_ip_netmask description"
 // @Param        MgmtIpGateway json     string    true "mgmt_ip_gateway description"
@@ -156,80 +137,7 @@ func getServers() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/server [post]
 func postServer(payload []byte) (interface{}, error) {
-	var v Server
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO server("
-	sqlString += "host_name"
-	sqlString += ",domain_name"
-	sqlString += ",tcp_port"
-	sqlString += ",xmpp_id"
-	sqlString += ",xmpp_passwd"
-	sqlString += ",interface_name"
-	sqlString += ",ip_address"
-	sqlString += ",ip_netmask"
-	sqlString += ",ip_gateway"
-	sqlString += ",ip6_address"
-	sqlString += ",ip6_gateway"
-	sqlString += ",interface_mtu"
-	sqlString += ",phys_location"
-	sqlString += ",rack"
-	sqlString += ",cachegroup"
-	sqlString += ",type"
-	sqlString += ",status"
-	sqlString += ",upd_pending"
-	sqlString += ",profile"
-	sqlString += ",cdn_id"
-	sqlString += ",mgmt_ip_address"
-	sqlString += ",mgmt_ip_netmask"
-	sqlString += ",mgmt_ip_gateway"
-	sqlString += ",ilo_ip_address"
-	sqlString += ",ilo_ip_netmask"
-	sqlString += ",ilo_ip_gateway"
-	sqlString += ",ilo_username"
-	sqlString += ",ilo_password"
-	sqlString += ",router_host_name"
-	sqlString += ",router_port_name"
-	sqlString += ") VALUES ("
-	sqlString += ":host_name"
-	sqlString += ",:domain_name"
-	sqlString += ",:tcp_port"
-	sqlString += ",:xmpp_id"
-	sqlString += ",:xmpp_passwd"
-	sqlString += ",:interface_name"
-	sqlString += ",:ip_address"
-	sqlString += ",:ip_netmask"
-	sqlString += ",:ip_gateway"
-	sqlString += ",:ip6_address"
-	sqlString += ",:ip6_gateway"
-	sqlString += ",:interface_mtu"
-	sqlString += ",:phys_location"
-	sqlString += ",:rack"
-	sqlString += ",:cachegroup"
-	sqlString += ",:type"
-	sqlString += ",:status"
-	sqlString += ",:upd_pending"
-	sqlString += ",:profile"
-	sqlString += ",:cdn_id"
-	sqlString += ",:mgmt_ip_address"
-	sqlString += ",:mgmt_ip_netmask"
-	sqlString += ",:mgmt_ip_gateway"
-	sqlString += ",:ilo_ip_address"
-	sqlString += ",:ilo_ip_netmask"
-	sqlString += ",:ilo_ip_gateway"
-	sqlString += ",:ilo_username"
-	sqlString += ",:ilo_password"
-	sqlString += ",:router_host_name"
-	sqlString += ",:router_port_name"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "server", (*Server)(nil))
 }
 
 // @Title putServer
@@ -237,85 +145,39 @@ func postServer(payload []byte) (interface{}, error) {
 // @Accept  application/json
 // @Param             HostName json     string   false "host_name description"
 // @Param           DomainName json     string   false "domain_name description"
-// @Param              TcpPort json   null.Int    true "tcp_port description"
-// @Param               XmppId json null.String    true "xmpp_id description"
-// @Param           XmppPasswd json null.String    true "xmpp_passwd description"
+// @Param              TcpPort json        int    true "tcp_port description"
+// @Param               XmppId json     string    true "xmpp_id description"
+// @Param           XmppPasswd json     string    true "xmpp_passwd description"
 // @Param        InterfaceName json     string   false "interface_name description"
 // @Param            IpAddress json     string   false "ip_address description"
 // @Param            IpNetmask json     string   false "ip_netmask description"
 // @Param            IpGateway json     string   false "ip_gateway description"
-// @Param           Ip6Address json null.String    true "ip6_address description"
-// @Param           Ip6Gateway json null.String    true "ip6_gateway description"
+// @Param           Ip6Address json     string    true "ip6_address description"
+// @Param           Ip6Gateway json     string    true "ip6_gateway description"
 // @Param         InterfaceMtu json      int64   false "interface_mtu description"
 // @Param         PhysLocation json      int64   false "phys_location description"
-// @Param                 Rack json null.String    true "rack description"
+// @Param                 Rack json     string    true "rack description"
 // @Param           Cachegroup json      int64   false "cachegroup description"
 // @Param                 Type json      int64   false "type description"
 // @Param               Status json      int64   false "status description"
 // @Param           UpdPending json      int64   false "upd_pending description"
 // @Param              Profile json      int64   false "profile description"
-// @Param                CdnId json      int64   false "cdn_id description"
-// @Param        MgmtIpAddress json null.String    true "mgmt_ip_address description"
-// @Param        MgmtIpNetmask json null.String    true "mgmt_ip_netmask description"
-// @Param        MgmtIpGateway json null.String    true "mgmt_ip_gateway description"
-// @Param         IloIpAddress json null.String    true "ilo_ip_address description"
-// @Param         IloIpNetmask json null.String    true "ilo_ip_netmask description"
-// @Param         IloIpGateway json null.String    true "ilo_ip_gateway description"
-// @Param          IloUsername json null.String    true "ilo_username description"
-// @Param          IloPassword json null.String    true "ilo_password description"
-// @Param       RouterHostName json null.String    true "router_host_name description"
-// @Param       RouterPortName json null.String    true "router_port_name description"
+// @Param                CdnId json        int    true "cdn_id description"
+// @Param        MgmtIpAddress json     string    true "mgmt_ip_address description"
+// @Param        MgmtIpNetmask json     string    true "mgmt_ip_netmask description"
+// @Param        MgmtIpGateway json     string    true "mgmt_ip_gateway description"
+// @Param         IloIpAddress json     string    true "ilo_ip_address description"
+// @Param         IloIpNetmask json     string    true "ilo_ip_netmask description"
+// @Param         IloIpGateway json     string    true "ilo_ip_gateway description"
+// @Param          IloUsername json     string    true "ilo_username description"
+// @Param          IloPassword json     string    true "ilo_password description"
+// @Param       RouterHostName json     string    true "router_host_name description"
+// @Param       RouterPortName json     string    true "router_port_name description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/server [put]
 func putServer(id int, payload []byte) (interface{}, error) {
-	var v Server
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE server SET "
-	sqlString += "host_name = :host_name"
-	sqlString += ",domain_name = :domain_name"
-	sqlString += ",tcp_port = :tcp_port"
-	sqlString += ",xmpp_id = :xmpp_id"
-	sqlString += ",xmpp_passwd = :xmpp_passwd"
-	sqlString += ",interface_name = :interface_name"
-	sqlString += ",ip_address = :ip_address"
-	sqlString += ",ip_netmask = :ip_netmask"
-	sqlString += ",ip_gateway = :ip_gateway"
-	sqlString += ",ip6_address = :ip6_address"
-	sqlString += ",ip6_gateway = :ip6_gateway"
-	sqlString += ",interface_mtu = :interface_mtu"
-	sqlString += ",phys_location = :phys_location"
-	sqlString += ",rack = :rack"
-	sqlString += ",cachegroup = :cachegroup"
-	sqlString += ",type = :type"
-	sqlString += ",status = :status"
-	sqlString += ",upd_pending = :upd_pending"
-	sqlString += ",profile = :profile"
-	sqlString += ",cdn_id = :cdn_id"
-	sqlString += ",mgmt_ip_address = :mgmt_ip_address"
-	sqlString += ",mgmt_ip_netmask = :mgmt_ip_netmask"
-	sqlString += ",mgmt_ip_gateway = :mgmt_ip_gateway"
-	sqlString += ",ilo_ip_address = :ilo_ip_address"
-	sqlString += ",ilo_ip_netmask = :ilo_ip_netmask"
-	sqlString += ",ilo_ip_gateway = :ilo_ip_gateway"
-	sqlString += ",ilo_username = :ilo_username"
-	sqlString += ",ilo_password = :ilo_password"
-	sqlString += ",router_host_name = :router_host_name"
-	sqlString += ",router_port_name = :router_port_name"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "server", (*Server)(nil))
 }
 
 // @Title delServerById
@@ -326,11 +188,5 @@ func putServer(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/server/{id} [delete]
 func delServer(id int) (interface{}, error) {
-	arg := Server{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM server WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "server")
 }

--- a/api/servercheck.go
+++ b/api/servercheck.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	null "gopkg.in/guregu/null.v3"
 	"time"
@@ -92,16 +89,7 @@ func getServercheck(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/servercheck/{id} [get]
 func getServercheckById(id int) (interface{}, error) {
-	ret := []Servercheck{}
-	arg := Servercheck{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from servercheck where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "servercheck", (*Servercheck)(nil))
 }
 
 // @Title getServerchecks
@@ -111,14 +99,7 @@ func getServercheckById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/servercheck [get]
 func getServerchecks() (interface{}, error) {
-	ret := []Servercheck{}
-	queryStr := "select * from servercheck"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("servercheck", (*Servercheck)(nil))
 }
 
 // @Title postServercheck
@@ -160,174 +141,49 @@ func getServerchecks() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/servercheck [post]
 func postServercheck(payload []byte) (interface{}, error) {
-	var v Servercheck
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO servercheck("
-	sqlString += "server"
-	sqlString += ",aa"
-	sqlString += ",ab"
-	sqlString += ",ac"
-	sqlString += ",ad"
-	sqlString += ",ae"
-	sqlString += ",af"
-	sqlString += ",ag"
-	sqlString += ",ah"
-	sqlString += ",ai"
-	sqlString += ",aj"
-	sqlString += ",ak"
-	sqlString += ",al"
-	sqlString += ",am"
-	sqlString += ",an"
-	sqlString += ",ao"
-	sqlString += ",ap"
-	sqlString += ",aq"
-	sqlString += ",ar"
-	sqlString += ",as"
-	sqlString += ",at"
-	sqlString += ",au"
-	sqlString += ",av"
-	sqlString += ",aw"
-	sqlString += ",ax"
-	sqlString += ",ay"
-	sqlString += ",az"
-	sqlString += ",ba"
-	sqlString += ",bb"
-	sqlString += ",bc"
-	sqlString += ",bd"
-	sqlString += ",be"
-	sqlString += ") VALUES ("
-	sqlString += ":server"
-	sqlString += ",:aa"
-	sqlString += ",:ab"
-	sqlString += ",:ac"
-	sqlString += ",:ad"
-	sqlString += ",:ae"
-	sqlString += ",:af"
-	sqlString += ",:ag"
-	sqlString += ",:ah"
-	sqlString += ",:ai"
-	sqlString += ",:aj"
-	sqlString += ",:ak"
-	sqlString += ",:al"
-	sqlString += ",:am"
-	sqlString += ",:an"
-	sqlString += ",:ao"
-	sqlString += ",:ap"
-	sqlString += ",:aq"
-	sqlString += ",:ar"
-	sqlString += ",:as"
-	sqlString += ",:at"
-	sqlString += ",:au"
-	sqlString += ",:av"
-	sqlString += ",:aw"
-	sqlString += ",:ax"
-	sqlString += ",:ay"
-	sqlString += ",:az"
-	sqlString += ",:ba"
-	sqlString += ",:bb"
-	sqlString += ",:bc"
-	sqlString += ",:bd"
-	sqlString += ",:be"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "servercheck", (*Servercheck)(nil))
 }
 
 // @Title putServercheck
 // @Description modify an existing servercheckentry
 // @Accept  application/json
 // @Param               Server json      int64   false "server description"
-// @Param                   Aa json   null.Int    true "aa description"
-// @Param                   Ab json   null.Int    true "ab description"
-// @Param                   Ac json   null.Int    true "ac description"
-// @Param                   Ad json   null.Int    true "ad description"
-// @Param                   Ae json   null.Int    true "ae description"
-// @Param                   Af json   null.Int    true "af description"
-// @Param                   Ag json   null.Int    true "ag description"
-// @Param                   Ah json   null.Int    true "ah description"
-// @Param                   Ai json   null.Int    true "ai description"
-// @Param                   Aj json   null.Int    true "aj description"
-// @Param                   Ak json   null.Int    true "ak description"
-// @Param                   Al json   null.Int    true "al description"
-// @Param                   Am json   null.Int    true "am description"
-// @Param                   An json   null.Int    true "an description"
-// @Param                   Ao json   null.Int    true "ao description"
-// @Param                   Ap json   null.Int    true "ap description"
-// @Param                   Aq json   null.Int    true "aq description"
-// @Param                   Ar json   null.Int    true "ar description"
-// @Param                   As json   null.Int    true "as description"
-// @Param                   At json   null.Int    true "at description"
-// @Param                   Au json   null.Int    true "au description"
-// @Param                   Av json   null.Int    true "av description"
-// @Param                   Aw json   null.Int    true "aw description"
-// @Param                   Ax json   null.Int    true "ax description"
-// @Param                   Ay json   null.Int    true "ay description"
-// @Param                   Az json   null.Int    true "az description"
-// @Param                   Ba json   null.Int    true "ba description"
-// @Param                   Bb json   null.Int    true "bb description"
-// @Param                   Bc json   null.Int    true "bc description"
-// @Param                   Bd json   null.Int    true "bd description"
-// @Param                   Be json   null.Int    true "be description"
+// @Param                   Aa json        int    true "aa description"
+// @Param                   Ab json        int    true "ab description"
+// @Param                   Ac json        int    true "ac description"
+// @Param                   Ad json        int    true "ad description"
+// @Param                   Ae json        int    true "ae description"
+// @Param                   Af json        int    true "af description"
+// @Param                   Ag json        int    true "ag description"
+// @Param                   Ah json        int    true "ah description"
+// @Param                   Ai json        int    true "ai description"
+// @Param                   Aj json        int    true "aj description"
+// @Param                   Ak json        int    true "ak description"
+// @Param                   Al json        int    true "al description"
+// @Param                   Am json        int    true "am description"
+// @Param                   An json        int    true "an description"
+// @Param                   Ao json        int    true "ao description"
+// @Param                   Ap json        int    true "ap description"
+// @Param                   Aq json        int    true "aq description"
+// @Param                   Ar json        int    true "ar description"
+// @Param                   As json        int    true "as description"
+// @Param                   At json        int    true "at description"
+// @Param                   Au json        int    true "au description"
+// @Param                   Av json        int    true "av description"
+// @Param                   Aw json        int    true "aw description"
+// @Param                   Ax json        int    true "ax description"
+// @Param                   Ay json        int    true "ay description"
+// @Param                   Az json        int    true "az description"
+// @Param                   Ba json        int    true "ba description"
+// @Param                   Bb json        int    true "bb description"
+// @Param                   Bc json        int    true "bc description"
+// @Param                   Bd json        int    true "bd description"
+// @Param                   Be json        int    true "be description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/servercheck [put]
 func putServercheck(id int, payload []byte) (interface{}, error) {
-	var v Servercheck
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE servercheck SET "
-	sqlString += "server = :server"
-	sqlString += ",aa = :aa"
-	sqlString += ",ab = :ab"
-	sqlString += ",ac = :ac"
-	sqlString += ",ad = :ad"
-	sqlString += ",ae = :ae"
-	sqlString += ",af = :af"
-	sqlString += ",ag = :ag"
-	sqlString += ",ah = :ah"
-	sqlString += ",ai = :ai"
-	sqlString += ",aj = :aj"
-	sqlString += ",ak = :ak"
-	sqlString += ",al = :al"
-	sqlString += ",am = :am"
-	sqlString += ",an = :an"
-	sqlString += ",ao = :ao"
-	sqlString += ",ap = :ap"
-	sqlString += ",aq = :aq"
-	sqlString += ",ar = :ar"
-	sqlString += ",as = :as"
-	sqlString += ",at = :at"
-	sqlString += ",au = :au"
-	sqlString += ",av = :av"
-	sqlString += ",aw = :aw"
-	sqlString += ",ax = :ax"
-	sqlString += ",ay = :ay"
-	sqlString += ",az = :az"
-	sqlString += ",ba = :ba"
-	sqlString += ",bb = :bb"
-	sqlString += ",bc = :bc"
-	sqlString += ",bd = :bd"
-	sqlString += ",be = :be"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "servercheck", (*Servercheck)(nil))
 }
 
 // @Title delServercheckById
@@ -338,11 +194,5 @@ func putServercheck(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/servercheck/{id} [delete]
 func delServercheck(id int) (interface{}, error) {
-	arg := Servercheck{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM servercheck WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "servercheck")
 }

--- a/api/staticdnsentry.go
+++ b/api/staticdnsentry.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	null "gopkg.in/guregu/null.v3"
 	"time"
@@ -66,16 +63,7 @@ func getStaticdnsentry(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/staticdnsentry/{id} [get]
 func getStaticdnsentryById(id int) (interface{}, error) {
-	ret := []Staticdnsentry{}
-	arg := Staticdnsentry{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from staticdnsentry where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "staticdnsentry", (*Staticdnsentry)(nil))
 }
 
 // @Title getStaticdnsentrys
@@ -85,14 +73,7 @@ func getStaticdnsentryById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/staticdnsentry [get]
 func getStaticdnsentrys() (interface{}, error) {
-	ret := []Staticdnsentry{}
-	queryStr := "select * from staticdnsentry"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("staticdnsentry", (*Staticdnsentry)(nil))
 }
 
 // @Title postStaticdnsentry
@@ -108,32 +89,7 @@ func getStaticdnsentrys() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/staticdnsentry [post]
 func postStaticdnsentry(payload []byte) (interface{}, error) {
-	var v Staticdnsentry
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO staticdnsentry("
-	sqlString += "host"
-	sqlString += ",address"
-	sqlString += ",type"
-	sqlString += ",ttl"
-	sqlString += ",deliveryservice"
-	sqlString += ",cachegroup"
-	sqlString += ") VALUES ("
-	sqlString += ":host"
-	sqlString += ",:address"
-	sqlString += ",:type"
-	sqlString += ",:ttl"
-	sqlString += ",:deliveryservice"
-	sqlString += ",:cachegroup"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "staticdnsentry", (*Staticdnsentry)(nil))
 }
 
 // @Title putStaticdnsentry
@@ -144,34 +100,12 @@ func postStaticdnsentry(payload []byte) (interface{}, error) {
 // @Param                 Type json      int64   false "type description"
 // @Param                  Ttl json      int64   false "ttl description"
 // @Param      Deliveryservice json      int64   false "deliveryservice description"
-// @Param           Cachegroup json   null.Int    true "cachegroup description"
+// @Param           Cachegroup json        int    true "cachegroup description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/staticdnsentry [put]
 func putStaticdnsentry(id int, payload []byte) (interface{}, error) {
-	var v Staticdnsentry
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE staticdnsentry SET "
-	sqlString += "host = :host"
-	sqlString += ",address = :address"
-	sqlString += ",type = :type"
-	sqlString += ",ttl = :ttl"
-	sqlString += ",deliveryservice = :deliveryservice"
-	sqlString += ",cachegroup = :cachegroup"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "staticdnsentry", (*Staticdnsentry)(nil))
 }
 
 // @Title delStaticdnsentryById
@@ -182,11 +116,5 @@ func putStaticdnsentry(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/staticdnsentry/{id} [delete]
 func delStaticdnsentry(id int) (interface{}, error) {
-	arg := Staticdnsentry{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM staticdnsentry WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "staticdnsentry")
 }

--- a/api/stats_summary.go
+++ b/api/stats_summary.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	"time"
 )
@@ -64,16 +61,7 @@ func getStatsSummary(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/stats_summary/{id} [get]
 func getStatsSummaryById(id int) (interface{}, error) {
-	ret := []StatsSummary{}
-	arg := StatsSummary{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from stats_summary where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "stats_summary", (*StatsSummary)(nil))
 }
 
 // @Title getStatsSummarys
@@ -83,14 +71,7 @@ func getStatsSummaryById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/stats_summary [get]
 func getStatsSummarys() (interface{}, error) {
-	ret := []StatsSummary{}
-	queryStr := "select * from stats_summary"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("stats_summary", (*StatsSummary)(nil))
 }
 
 // @Title postStatsSummary
@@ -106,32 +87,7 @@ func getStatsSummarys() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/stats_summary [post]
 func postStatsSummary(payload []byte) (interface{}, error) {
-	var v StatsSummary
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO stats_summary("
-	sqlString += "cdn_name"
-	sqlString += ",deliveryservice_name"
-	sqlString += ",stat_name"
-	sqlString += ",stat_value"
-	sqlString += ",summary_time"
-	sqlString += ",stat_date"
-	sqlString += ") VALUES ("
-	sqlString += ":cdn_name"
-	sqlString += ",:deliveryservice_name"
-	sqlString += ",:stat_name"
-	sqlString += ",:stat_value"
-	sqlString += ",:summary_time"
-	sqlString += ",:stat_date"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "stats_summary", (*StatsSummary)(nil))
 }
 
 // @Title putStatsSummary
@@ -147,27 +103,7 @@ func postStatsSummary(payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/stats_summary [put]
 func putStatsSummary(id int, payload []byte) (interface{}, error) {
-	var v StatsSummary
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	sqlString := "UPDATE stats_summary SET "
-	sqlString += "cdn_name = :cdn_name"
-	sqlString += ",deliveryservice_name = :deliveryservice_name"
-	sqlString += ",stat_name = :stat_name"
-	sqlString += ",stat_value = :stat_value"
-	sqlString += ",summary_time = :summary_time"
-	sqlString += ",stat_date = :stat_date"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "stats_summary", (*StatsSummary)(nil))
 }
 
 // @Title delStatsSummaryById
@@ -178,11 +114,5 @@ func putStatsSummary(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/stats_summary/{id} [delete]
 func delStatsSummary(id int) (interface{}, error) {
-	arg := StatsSummary{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM stats_summary WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "stats_summary")
 }

--- a/api/status.go
+++ b/api/status.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	null "gopkg.in/guregu/null.v3"
 	"time"
@@ -62,16 +59,7 @@ func getStatus(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/status/{id} [get]
 func getStatusById(id int) (interface{}, error) {
-	ret := []Status{}
-	arg := Status{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from status where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "status", (*Status)(nil))
 }
 
 // @Title getStatuss
@@ -81,14 +69,7 @@ func getStatusById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/status [get]
 func getStatuss() (interface{}, error) {
-	ret := []Status{}
-	queryStr := "select * from status"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("status", (*Status)(nil))
 }
 
 // @Title postStatus
@@ -100,54 +81,19 @@ func getStatuss() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/status [post]
 func postStatus(payload []byte) (interface{}, error) {
-	var v Status
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO status("
-	sqlString += "name"
-	sqlString += ",description"
-	sqlString += ") VALUES ("
-	sqlString += ":name"
-	sqlString += ",:description"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "status", (*Status)(nil))
 }
 
 // @Title putStatus
 // @Description modify an existing statusentry
 // @Accept  application/json
 // @Param                 Name json     string   false "name description"
-// @Param          Description json null.String    true "description description"
+// @Param          Description json     string    true "description description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/status [put]
 func putStatus(id int, payload []byte) (interface{}, error) {
-	var v Status
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE status SET "
-	sqlString += "name = :name"
-	sqlString += ",description = :description"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "status", (*Status)(nil))
 }
 
 // @Title delStatusById
@@ -158,11 +104,5 @@ func putStatus(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/status/{id} [delete]
 func delStatus(id int) (interface{}, error) {
-	arg := Status{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM status WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "status")
 }

--- a/api/tm_user.go
+++ b/api/tm_user.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	null "gopkg.in/guregu/null.v3"
 	"time"
@@ -80,16 +77,7 @@ func getTmUser(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/tm_user/{id} [get]
 func getTmUserById(id int) (interface{}, error) {
-	ret := []TmUser{}
-	arg := TmUser{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from tm_user where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "tm_user", (*TmUser)(nil))
 }
 
 // @Title getTmUsers
@@ -99,14 +87,7 @@ func getTmUserById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/tm_user [get]
 func getTmUsers() (interface{}, error) {
-	ret := []TmUser{}
-	queryStr := "select * from tm_user"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("tm_user", (*TmUser)(nil))
 }
 
 // @Title postTmUser
@@ -136,126 +117,37 @@ func getTmUsers() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/tm_user [post]
 func postTmUser(payload []byte) (interface{}, error) {
-	var v TmUser
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO tm_user("
-	sqlString += "username"
-	sqlString += ",role"
-	sqlString += ",uid"
-	sqlString += ",gid"
-	sqlString += ",local_passwd"
-	sqlString += ",confirm_local_passwd"
-	sqlString += ",company"
-	sqlString += ",email"
-	sqlString += ",full_name"
-	sqlString += ",new_user"
-	sqlString += ",address_line1"
-	sqlString += ",address_line2"
-	sqlString += ",city"
-	sqlString += ",state_or_province"
-	sqlString += ",phone_number"
-	sqlString += ",postal_code"
-	sqlString += ",country"
-	sqlString += ",local_user"
-	sqlString += ",token"
-	sqlString += ",registration_sent"
-	sqlString += ") VALUES ("
-	sqlString += ":username"
-	sqlString += ",:role"
-	sqlString += ",:uid"
-	sqlString += ",:gid"
-	sqlString += ",:local_passwd"
-	sqlString += ",:confirm_local_passwd"
-	sqlString += ",:company"
-	sqlString += ",:email"
-	sqlString += ",:full_name"
-	sqlString += ",:new_user"
-	sqlString += ",:address_line1"
-	sqlString += ",:address_line2"
-	sqlString += ",:city"
-	sqlString += ",:state_or_province"
-	sqlString += ",:phone_number"
-	sqlString += ",:postal_code"
-	sqlString += ",:country"
-	sqlString += ",:local_user"
-	sqlString += ",:token"
-	sqlString += ",:registration_sent"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "tm_user", (*TmUser)(nil))
 }
 
 // @Title putTmUser
 // @Description modify an existing tm_userentry
 // @Accept  application/json
-// @Param             Username json null.String    true "username description"
-// @Param                 Role json   null.Int    true "role description"
-// @Param                  Uid json   null.Int    true "uid description"
-// @Param                  Gid json   null.Int    true "gid description"
-// @Param          LocalPasswd json null.String    true "local_passwd description"
-// @Param   ConfirmLocalPasswd json null.String    true "confirm_local_passwd description"
-// @Param              Company json null.String    true "company description"
-// @Param                Email json null.String    true "email description"
-// @Param             FullName json null.String    true "full_name description"
+// @Param             Username json     string    true "username description"
+// @Param                 Role json        int    true "role description"
+// @Param                  Uid json        int    true "uid description"
+// @Param                  Gid json        int    true "gid description"
+// @Param          LocalPasswd json     string    true "local_passwd description"
+// @Param   ConfirmLocalPasswd json     string    true "confirm_local_passwd description"
+// @Param              Company json     string    true "company description"
+// @Param                Email json     string    true "email description"
+// @Param             FullName json     string    true "full_name description"
 // @Param              NewUser json      int64   false "new_user description"
-// @Param         AddressLine1 json null.String    true "address_line1 description"
-// @Param         AddressLine2 json null.String    true "address_line2 description"
-// @Param                 City json null.String    true "city description"
-// @Param      StateOrProvince json null.String    true "state_or_province description"
-// @Param          PhoneNumber json null.String    true "phone_number description"
-// @Param           PostalCode json null.String    true "postal_code description"
-// @Param              Country json null.String    true "country description"
+// @Param         AddressLine1 json     string    true "address_line1 description"
+// @Param         AddressLine2 json     string    true "address_line2 description"
+// @Param                 City json     string    true "city description"
+// @Param      StateOrProvince json     string    true "state_or_province description"
+// @Param          PhoneNumber json     string    true "phone_number description"
+// @Param           PostalCode json     string    true "postal_code description"
+// @Param              Country json     string    true "country description"
 // @Param            LocalUser json      int64   false "local_user description"
-// @Param                Token json null.String    true "token description"
+// @Param                Token json     string    true "token description"
 // @Param     RegistrationSent json  time.Time   false "registration_sent description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/tm_user [put]
 func putTmUser(id int, payload []byte) (interface{}, error) {
-	var v TmUser
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE tm_user SET "
-	sqlString += "username = :username"
-	sqlString += ",role = :role"
-	sqlString += ",uid = :uid"
-	sqlString += ",gid = :gid"
-	sqlString += ",local_passwd = :local_passwd"
-	sqlString += ",confirm_local_passwd = :confirm_local_passwd"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += ",company = :company"
-	sqlString += ",email = :email"
-	sqlString += ",full_name = :full_name"
-	sqlString += ",new_user = :new_user"
-	sqlString += ",address_line1 = :address_line1"
-	sqlString += ",address_line2 = :address_line2"
-	sqlString += ",city = :city"
-	sqlString += ",state_or_province = :state_or_province"
-	sqlString += ",phone_number = :phone_number"
-	sqlString += ",postal_code = :postal_code"
-	sqlString += ",country = :country"
-	sqlString += ",local_user = :local_user"
-	sqlString += ",token = :token"
-	sqlString += ",registration_sent = :registration_sent"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "tm_user", (*TmUser)(nil))
 }
 
 // @Title delTmUserById
@@ -266,11 +158,5 @@ func putTmUser(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/tm_user/{id} [delete]
 func delTmUser(id int) (interface{}, error) {
-	arg := TmUser{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM tm_user WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "tm_user")
 }

--- a/api/to_extension.go
+++ b/api/to_extension.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	null "gopkg.in/guregu/null.v3"
 	"time"
@@ -70,16 +67,7 @@ func getToExtension(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/to_extension/{id} [get]
 func getToExtensionById(id int) (interface{}, error) {
-	ret := []ToExtension{}
-	arg := ToExtension{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from to_extension where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "to_extension", (*ToExtension)(nil))
 }
 
 // @Title getToExtensions
@@ -89,14 +77,7 @@ func getToExtensionById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/to_extension [get]
 func getToExtensions() (interface{}, error) {
-	ret := []ToExtension{}
-	queryStr := "select * from to_extension"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("to_extension", (*ToExtension)(nil))
 }
 
 // @Title postToExtension
@@ -116,40 +97,7 @@ func getToExtensions() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/to_extension [post]
 func postToExtension(payload []byte) (interface{}, error) {
-	var v ToExtension
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO to_extension("
-	sqlString += "name"
-	sqlString += ",version"
-	sqlString += ",info_url"
-	sqlString += ",script_file"
-	sqlString += ",isactive"
-	sqlString += ",additional_config_json"
-	sqlString += ",description"
-	sqlString += ",servercheck_short_name"
-	sqlString += ",servercheck_column_name"
-	sqlString += ",type"
-	sqlString += ") VALUES ("
-	sqlString += ":name"
-	sqlString += ",:version"
-	sqlString += ",:info_url"
-	sqlString += ",:script_file"
-	sqlString += ",:isactive"
-	sqlString += ",:additional_config_json"
-	sqlString += ",:description"
-	sqlString += ",:servercheck_short_name"
-	sqlString += ",:servercheck_column_name"
-	sqlString += ",:type"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "to_extension", (*ToExtension)(nil))
 }
 
 // @Title putToExtension
@@ -160,42 +108,16 @@ func postToExtension(payload []byte) (interface{}, error) {
 // @Param              InfoUrl json     string   false "info_url description"
 // @Param           ScriptFile json     string   false "script_file description"
 // @Param             Isactive json      int64   false "isactive description"
-// @Param AdditionalConfigJson json null.String    true "additional_config_json description"
-// @Param          Description json null.String    true "description description"
-// @Param ServercheckShortName json null.String    true "servercheck_short_name description"
-// @Param ServercheckColumnName json null.String    true "servercheck_column_name description"
+// @Param AdditionalConfigJson json     string    true "additional_config_json description"
+// @Param          Description json     string    true "description description"
+// @Param ServercheckShortName json     string    true "servercheck_short_name description"
+// @Param ServercheckColumnName json     string    true "servercheck_column_name description"
 // @Param                 Type json      int64   false "type description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/to_extension [put]
 func putToExtension(id int, payload []byte) (interface{}, error) {
-	var v ToExtension
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE to_extension SET "
-	sqlString += "name = :name"
-	sqlString += ",version = :version"
-	sqlString += ",info_url = :info_url"
-	sqlString += ",script_file = :script_file"
-	sqlString += ",isactive = :isactive"
-	sqlString += ",additional_config_json = :additional_config_json"
-	sqlString += ",description = :description"
-	sqlString += ",servercheck_short_name = :servercheck_short_name"
-	sqlString += ",servercheck_column_name = :servercheck_column_name"
-	sqlString += ",type = :type"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "to_extension", (*ToExtension)(nil))
 }
 
 // @Title delToExtensionById
@@ -206,11 +128,5 @@ func putToExtension(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/to_extension/{id} [delete]
 func delToExtension(id int) (interface{}, error) {
-	arg := ToExtension{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM to_extension WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "to_extension")
 }

--- a/api/type.go
+++ b/api/type.go
@@ -18,9 +18,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/goto2/db"
 	_ "github.com/Comcast/traffic_control/traffic_ops/goto2/output_format" // needed for swagger
 	null "gopkg.in/guregu/null.v3"
 	"time"
@@ -63,16 +60,7 @@ func getType(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/type/{id} [get]
 func getTypeById(id int) (interface{}, error) {
-	ret := []Type{}
-	arg := Type{Id: int64(id)}
-	nstmt, err := db.GlobalDB.PrepareNamed(`select * from type where id=:id`)
-	err = nstmt.Select(&ret, arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	nstmt.Close()
-	return ret, nil
+	return genericGetById(id, "type", (*Type)(nil))
 }
 
 // @Title getTypes
@@ -82,14 +70,7 @@ func getTypeById(id int) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/type [get]
 func getTypes() (interface{}, error) {
-	ret := []Type{}
-	queryStr := "select * from type"
-	err := db.GlobalDB.Select(&ret, queryStr)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return ret, nil
+	return genericGet("type", (*Type)(nil))
 }
 
 // @Title postType
@@ -102,58 +83,20 @@ func getTypes() (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/type [post]
 func postType(payload []byte) (interface{}, error) {
-	var v Type
-	err := json.Unmarshal(payload, &v)
-	if err != nil {
-		fmt.Println(err)
-	}
-	sqlString := "INSERT INTO type("
-	sqlString += "name"
-	sqlString += ",description"
-	sqlString += ",use_in_table"
-	sqlString += ") VALUES ("
-	sqlString += ":name"
-	sqlString += ",:description"
-	sqlString += ",:use_in_table"
-	sqlString += ")"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPost(payload, "type", (*Type)(nil))
 }
 
 // @Title putType
 // @Description modify an existing typeentry
 // @Accept  application/json
 // @Param                 Name json     string   false "name description"
-// @Param          Description json null.String    true "description description"
-// @Param           UseInTable json null.String    true "use_in_table description"
+// @Param          Description json     string    true "description description"
+// @Param           UseInTable json     string    true "use_in_table description"
 // @Success 200 {object}    output_format.ApiWrapper
 // @Resource /api/2.0
 // @Router /api/2.0/type [put]
 func putType(id int, payload []byte) (interface{}, error) {
-	var v Type
-	err := json.Unmarshal(payload, &v)
-	v.Id = int64(id) // overwrite the id in the payload
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	v.LastUpdated = time.Now()
-	sqlString := "UPDATE type SET "
-	sqlString += "name = :name"
-	sqlString += ",description = :description"
-	sqlString += ",use_in_table = :use_in_table"
-	sqlString += ",last_updated = :last_updated"
-	sqlString += " WHERE id=:id"
-	result, err := db.GlobalDB.NamedExec(sqlString, v)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericPut(id, payload, "type", (*Type)(nil))
 }
 
 // @Title delTypeById
@@ -164,11 +107,5 @@ func putType(id int, payload []byte) (interface{}, error) {
 // @Resource /api/2.0
 // @Router /api/2.0/type/{id} [delete]
 func delType(id int) (interface{}, error) {
-	arg := Type{Id: int64(id)}
-	result, err := db.GlobalDB.NamedExec("DELETE FROM type WHERE id=:id", arg)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	return result, err
+	return genericDelete(id, "type")
 }

--- a/tools/gen_goto2.go
+++ b/tools/gen_goto2.go
@@ -31,8 +31,8 @@ var defaults = Configuration{
 	DbUser:     os.Args[1],
 	DbPassword: os.Args[2],
 	DbName:     os.Args[3],
-	DbServer:   os.Args[4],
-	DbPort:     os.Args[5],
+	DbServer:   "localhost",
+	DbPort:     "3306",
 	PkgName:    "api",
 	TagLabel:   "db",
 }
@@ -427,6 +427,12 @@ func goType(col *ColumnSchema) (string, string, error) {
 func main() {
 
 	config = defaults
+	if len(os.Args) > 4 {
+		config.DbServer = os.Args[4]
+	}
+	if len(os.Args) > 5 {
+		config.DbPort = os.Args[5]
+	}
 
 	columns, tables := getSchema()
 	fmt.Println(tables)


### PR DESCRIPTION
We might ought to discuss how we feel about this.

There's no good answer; only a question of which is the lesser evil. Using Reflection for generics is run-time and not type-safe. A code generator is hard to read. If we consider the generated code as "code," it's duplicate.

Personally, I'm leaning toward the generics. If we isolate them, and keep them in their own package, we can kind of 'quarantine' the type-unsafety. It's also one less build step, if we eliminate the generator entirely (I'm still trying to figure out if that's possible, or desirable). There's nothing wrong with code generation in general, but Go doesn't have any tools to do it, so you have to print strings, which is kind of hard to read. And even if it's generated, the api still _looks_ very duplicate. I could be being irrational there. My 2¢.

Also, for what it's worth, these last few days changed my opinion about `interface{}`. I still think it's bad, but I've become convinced it's necessary in complex things.

Thoughts?
